### PR TITLE
C3-104: Support for number of CPUs and main memory size (flavors) in libretto

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -429,10 +429,21 @@ var cloneFromTemplate = func(vm *VM, dcMo *mo.Datacenter, usableDatastores []str
 		Datastore: &dsMor,
 	}
 
+        MemoryHotAddEnabled := true
+        CpuHotAddEnabled := true
+
+        config := types.VirtualMachineConfigSpec{
+                NumCPUs:        vm.Flavor.NumCPUs,
+                MemoryMB:       vm.Flavor.MemoryMB,
+                MemoryHotAddEnabled:    &MemoryHotAddEnabled,
+                CpuHotAddEnabled:       &CpuHotAddEnabled,
+        }
+
 	cisp := types.VirtualMachineCloneSpec{
 		Location: relocateSpec,
 		Template: false,
 		PowerOn:  false,
+		Config:   &config,
 	}
 
 	// To create a linked clone, we need to set the DiskMoveType and reference
@@ -448,6 +459,7 @@ var cloneFromTemplate = func(vm *VM, dcMo *mo.Datacenter, usableDatastores []str
 			Location: relocateSpec,
 			Template: false,
 			PowerOn:  false,
+			Config:   &config,
 			Snapshot: vmMo.Snapshot.CurrentSnapshot,
 		}
 	}

--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -429,14 +429,14 @@ var cloneFromTemplate = func(vm *VM, dcMo *mo.Datacenter, usableDatastores []str
 		Datastore: &dsMor,
 	}
 
-        MemoryHotAddEnabled := true
-        CpuHotAddEnabled := true
+        hotAddMemory := true
+        hotAddCpu := true
 
         config := types.VirtualMachineConfigSpec{
                 NumCPUs:        vm.Flavor.NumCPUs,
                 MemoryMB:       vm.Flavor.MemoryMB,
-                MemoryHotAddEnabled:    &MemoryHotAddEnabled,
-                CpuHotAddEnabled:       &CpuHotAddEnabled,
+                MemoryHotAddEnabled:    &hotAddMemory,
+                CpuHotAddEnabled:       &hotAddCpu,
         }
 
 	cisp := types.VirtualMachineCloneSpec{

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -307,6 +307,13 @@ type Lease interface {
 	Complete() error
 }
 
+type Flavor struct {
+        // Represents the number of CPUs
+        NumCPUs int32
+        // Represents the size of main memory in MB
+        MemoryMB int64
+}
+
 var _ lvm.VirtualMachine = (*VM)(nil)
 
 // VM represents a vSphere VM.
@@ -323,6 +330,8 @@ type VM struct {
 	Insecure bool
 	// Datacenter configures the datacenter onto which to import the VM.
 	Datacenter string
+        //Flavor for the number of CPUs and size of main memory
+        Flavor Flavor
 	// OvfPath represents the location of the OVF file on disk.
 	OvfPath string
 	// OvaPathUrl represents the location of local/remote ova file


### PR DESCRIPTION
**Jira ID**
[C3-104](https://apporbit.atlassian.net/browse/C3-104)

**Problem**
Cannot specify the number of CPUs and the main memory of the virtual machine as not supported

**Solution**
Introduced Flavor in vm struct and added to the virtualmachine clone spec before cloning the VM

**Testing**
Provisioned the VM with CPU count 4 and Ram size 8192 MB. The VM is created with the specified number of CPUs and RAM size.

**Automated Testing**
NA