### PR TITLE
C3-142 : Issue while create VM with Private Network

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -400,6 +400,55 @@ func searchTree(vm *VM, mor types.ManagedObjectReference, name string) (*mo.Virt
 	return nil, NewErrorObjectNotFound(errors.New("could not find the vm"), name)
 }
 
+// reconfigureNetworks : reconfigureNetworks configures the vm and attach it to the
+// netowrks in the vm structure
+func reconfigureNetworks(vm *VM) ([]types.BaseVirtualDeviceConfigSpec, error) {
+	var deviceSpecs []types.BaseVirtualDeviceConfigSpec
+	dcMo, err := GetDatacenter(vm)
+	if err != nil {
+		return nil, err
+	}
+	l, err := getVMLocation(vm, dcMo)
+	if err != nil {
+		return nil, err
+	}
+	// Create mapping of network managed object and network name
+	networkMapping, err := createNetworkMapping(vm, vm.Networks, l.Networks)
+	if err != nil {
+		return nil, err
+	}
+
+	// for all the mappings create a nic and add network backing info to it
+	// create deviceSpec array from  the mapping
+	for _, mapping := range networkMapping {
+		// create backing object
+		backing := &types.VirtualEthernetCardNetworkBackingInfo{
+			VirtualDeviceDeviceBackingInfo: types.VirtualDeviceDeviceBackingInfo{
+				DeviceName: mapping.Name,
+			},
+			Network: &mapping.Network,
+		}
+		// create ehternet car with the backing info
+		device, err := object.EthernetCardTypes().CreateEthernetCard("e1000", backing)
+		if err != nil {
+			return nil, err
+		}
+		// connect to the newtork when the nic is connected to vm
+		device.GetVirtualDevice().Connectable = &types.VirtualDeviceConnectInfo{
+			StartConnected:    true,
+			AllowGuestControl: true,
+		}
+		// create spec to add the device to the vm
+		spec := &types.VirtualDeviceConfigSpec{
+			Operation: types.VirtualDeviceConfigSpecOperationAdd,
+			Device:    device,
+		}
+		// add spec to array of the devices to be added/removed
+		deviceSpecs = append(deviceSpecs, spec)
+	}
+	return deviceSpecs, nil
+}
+
 var cloneFromTemplate = func(vm *VM, dcMo *mo.Datacenter, usableDatastores []string) error {
 	n := util.Random(1, len(usableDatastores))
 	vm.datastore = usableDatastores[n-1]
@@ -429,6 +478,10 @@ var cloneFromTemplate = func(vm *VM, dcMo *mo.Datacenter, usableDatastores []str
 		Datastore: &dsMor,
 	}
 
+	deviceChangeSpec, err := reconfigureNetworks(vm)
+	if err != nil {
+		return err
+	}
 	hotAddMemory := true
 	hotAddCpu := true
 
@@ -438,6 +491,7 @@ var cloneFromTemplate = func(vm *VM, dcMo *mo.Datacenter, usableDatastores []str
 		MemoryHotAddEnabled: &hotAddMemory,
 		CpuHotAddEnabled:    &hotAddCpu,
 	}
+	config.DeviceChange = deviceChangeSpec
 
 	cisp := types.VirtualMachineCloneSpec{
 		Location: relocateSpec,


### PR DESCRIPTION
Jira Id

C3-142

**Problem**

Cannot create vm with networks other than 'VM Network'

**Solution**

Added support for adding the networks specified in the vm struct

**Testing** 

**Unit Testing**

Done. Tried to create vm with VMprivate-network, the vm was assigned with the VMprivate-network, and a local ip is assigned to the vm.

[root@localhost test]# go run vsphereclient.go
Vm created and is powered on
{"IPs":["10.10.24.209","fe80::72cd:ca68:a895:5ae0","fe80::8d39:b744:d6bd:9a0d"]}