### PR TITLE
C3-195 : Return vmdk file name as response from add disk operation

### DIFF
--- a/virtualmachine/virtualmachine.go
+++ b/virtualmachine/virtualmachine.go
@@ -22,7 +22,7 @@ type VirtualMachine interface {
 	Halt() error
 	Start() error
 	GetSSH(ssh.Options) (ssh.Client, error)
-	AddDisk() error
+	AddDisk() ([]string, error)
 	RemoveDisk(string) error
 }
 

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -469,9 +469,9 @@ func (vm *VM) GetName() string {
 }
 
 // AddDisk to the vm
-func (vm *VM) AddDisk() error {
+func (vm *VM) AddDisk() ([]string, error) {
 	if err := SetupSession(vm); err != nil {
-		return fmt.Errorf("Error setting up vSphere session: %s", err)
+		return nil, fmt.Errorf("Error setting up vSphere session: %s", err)
 	}
 
 	// Cancel the sdk context
@@ -480,13 +480,13 @@ func (vm *VM) AddDisk() error {
 	// Get a reference to the datacenter with host and vm folders populated
 	dcMo, err := GetDatacenter(vm)
 	if err != nil {
-		return fmt.Errorf("Failed to retrieve datacenter: %s", err)
+		return nil, fmt.Errorf("Failed to retrieve datacenter: %s", err)
 	}
 
 	// Finds the vm with name vm.Name
 	vmMo, err := findVM(vm, dcMo, vm.Name)
 	if err != nil {
-		return fmt.Errorf("VM not found", vm.Name, err)
+		return nil, fmt.Errorf("VM not found", vm.Name, err)
 	}
 
 	// Gets a random datastore from the list of datastores to create disk
@@ -494,10 +494,11 @@ func (vm *VM) AddDisk() error {
 	vm.datastore = vm.Datastores[n-1]
 
 	// Reconfigures vm with the new Disk
-	if err := reconfigureVM(vm, vmMo); err != nil {
-		return fmt.Errorf("Reconfigure failed : ", err)
+	diskList, err := reconfigureVM(vm, vmMo)
+	if err != nil {
+		return nil, fmt.Errorf("Reconfigure failed : ", err)
 	}
-	return nil
+	return diskList, nil
 }
 
 // RemoveDisk removes the disk attached to the virtualmachine 'vm', vmdkName is the name of the vmdk file for the disk


### PR DESCRIPTION
**Jira ID**

C3-195

**Problem**

Return vmdk file name as response from add disk operation

**Description**

The add Disk operation in libretto doesn't return anything if the operation is success and returns error in case of failure. The vmdk File name will be used in the remove disk operation for which the vmdk file name needs to be returned when the add disk operation is done.

**Testing**

Manual testing

[root@localhost test]# go run vsphereclient.go
Vm created and is powered on
{"IPs":["67.220.185.220","fe80::250:56ff:fe9e:2086"]}
Sleeping for 10 seconds
Disks added [[datastore1] vm_name_1/vm_name_1_2.vmdk [datastore1] vm_name_1/vm_name_1_3.vmdk]
Sleeping for 10 seconds
VM destroyed