### PR TITLE
Remove Disk updated to take string slice of the disks to be removed

### DIFF
--- a/virtualmachine/virtualmachine.go
+++ b/virtualmachine/virtualmachine.go
@@ -23,7 +23,7 @@ type VirtualMachine interface {
 	Start() error
 	GetSSH(ssh.Options) (ssh.Client, error)
 	AddDisk() ([]string, error)
-	RemoveDisk(string) error
+	RemoveDisk([]string) error
 }
 
 const (

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -525,7 +525,8 @@ func (vm *VM) AddDisk() ([]string, error) {
 }
 
 // RemoveDisk removes the disk attached to the virtualmachine 'vm', vmdkName is the name of the vmdk file for the disk
-func (vm *VM) RemoveDisk(vmdkName string) (err error) {
+func (vm *VM) RemoveDisk(vmdkFiles []string) error {
+	var errorMessage string
 	if err := SetupSession(vm); err != nil {
 		return fmt.Errorf("Error setting up vSphere session: %s", err)
 	}
@@ -539,35 +540,42 @@ func (vm *VM) RemoveDisk(vmdkName string) (err error) {
 		return fmt.Errorf("Failed to retrieve datacenter: %s", err)
 	}
 
-	// finds the virtualmachine with name vm.Name
-	vmMo, err := findVM(vm, dcMo, vm.Name)
-	if err != nil {
-		return fmt.Errorf("VM not found", vm.Name, err)
-	}
+	errorMessage = ""
+	for _, vmdkName := range vmdkFiles {
+		// finds the virtualmachine with name vm.Name
+		vmMo, err := findVM(vm, dcMo, vm.Name)
+		if err != nil {
+			return fmt.Errorf("VM not found", vm.Name, err)
+		}
 
-	// find the virtual disk to be removed from the vm
-	var deviceMo *types.VirtualDisk
-	for _, d := range vmMo.Config.Hardware.Device {
-		switch device := d.(type) {
-		case *types.VirtualDisk:
-			fileName := d.GetVirtualDevice().Backing.(types.BaseVirtualDeviceFileBackingInfo).GetVirtualDeviceFileBackingInfo().FileName
-			if strings.HasSuffix(fileName, vmdkName) {
-				deviceMo = device
-				break
+		// find the virtual disk to be removed from the vm
+		var deviceMo *types.VirtualDisk
+		for _, d := range vmMo.Config.Hardware.Device {
+			switch device := d.(type) {
+			case *types.VirtualDisk:
+				fileName := d.GetVirtualDevice().Backing.(types.BaseVirtualDeviceFileBackingInfo).GetVirtualDeviceFileBackingInfo().FileName
+				if strings.HasSuffix(fileName, vmdkName) {
+					deviceMo = device
+					break
+				}
 			}
 		}
-	}
 
-	if deviceMo == nil {
-		return fmt.Errorf("No disk with name %s", vmdkName)
-	}
+		if deviceMo == nil {
+			errorMessage += fmt.Sprintf("%s : No disk with name\n", vmdkName)
+			continue
+		}
 
-	// Creates the virtualmachine object to remove the disk
-	vmo := object.NewVirtualMachine(vm.client.Client, vmMo.Reference())
-	if err = vmo.RemoveDevice(vm.ctx, false, deviceMo); err != nil {
-		fmt.Errorf("Delete disk task returned an error : ", err)
+		// Creates the virtualmachine object to remove the disk
+		vmo := object.NewVirtualMachine(vm.client.Client, vmMo.Reference())
+		if err = vmo.RemoveDevice(vm.ctx, false, deviceMo); err != nil {
+			errorMessage += fmt.Errorf("%s : Delete disk task returned an error : %s \n", vmdkName, err).Error()
+		}
 	}
-	return nil
+	if errorMessage == "" {
+		return nil
+	}
+	return errors.New(errorMessage)
 }
 
 // GetIPs returns the IPs of this VM. Returns all the IPs known to the API for

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -540,7 +540,6 @@ func (vm *VM) RemoveDisk(vmdkFiles []string) error {
 		return fmt.Errorf("Failed to retrieve datacenter: %s", err)
 	}
 
-	errorMessage = ""
 	for _, vmdkName := range vmdkFiles {
 		// finds the virtualmachine with name vm.Name
 		vmMo, err := findVM(vm, dcMo, vm.Name)
@@ -572,10 +571,10 @@ func (vm *VM) RemoveDisk(vmdkFiles []string) error {
 			errorMessage += fmt.Errorf("%s : Delete disk task returned an error : %s \n", vmdkName, err).Error()
 		}
 	}
-	if errorMessage == "" {
-		return nil
+	if errorMessage != "" {
+		return errors.New(errorMessage)
 	}
-	return errors.New(errorMessage)
+	return nil
 }
 
 // GetIPs returns the IPs of this VM. Returns all the IPs known to the API for


### PR DESCRIPTION
**Problem**

Support for deleting multiple volumes is not there

**Solution**

Support to delete multiple volumes added to libretto. Taking string slice of the vmdk file names to be removed from the vm. Loop through the slice and remove the volumes.