### PR TITLE
C3-254: Support for get_network_list call with filter (cluster and host level filter)

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -30,6 +30,15 @@ import (
 	lvm "github.com/apcera/libretto/virtualmachine"
 )
 
+func StringInSlice(str string, list []string) bool {
+	for _, v := range list {
+		if v == str {
+			return true
+		}
+	}
+	return false
+}
+
 // Exists checks if the VM already exists.
 var Exists = func(vm *VM, dc *mo.Datacenter, tName string) (bool, error) {
 	_, err := findVM(vm, dc, tName)

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -995,9 +995,20 @@ func GetDcNetworkList(vm *VM, filter map[string][]string) ([]map[string]string, 
 		dest := Destination{}
 		dest.DestinationName = cluster
 		dest.DestinationType = "cluster"
+		vm.Destination = dest
+		hostsInCluster, err := GetHostList(vm)
+		if err != nil {
+			return nil, err
+		}
+		hostList := make([]string, 0)
+		for _, host := range hostsInCluster {
+			hostList = append(hostList, host["name"])
+		}
 		for _, host := range hosts {
-			dest.HostSystem = host
-			destHostList = append(destHostList, dest)
+			if StringInSlice(host, hostList) {
+				dest.HostSystem = host
+				destHostList = append(destHostList, dest)
+			}
 		}
 	}
 

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -448,7 +448,6 @@ func (vm *VM) Provision() (err error) {
 			case SKIPTEMPLATE_ERROR:
 				return fmt.Errorf("Template already exists: %s", vm.Template)
 			case SKIPTEMPLATE_OVERWRITE:
-				fmt.Println("Overwriting Template")
 				if err := DeleteTemplate(vm); err != nil {
 					return err
 				}
@@ -837,54 +836,161 @@ func DeleteTemplate(vm *VM) error {
 	return nil
 }
 
-// GetDcNetworkList : GetDcNetworkList returns the list of networks in
-// all the datacenters in vcenter server
-func GetDcNetworkList(vm *VM) (map[string][]string, error) {
-	networkList := map[string][]string{}
+// GetDatastoreInHost : Returns the datastores in a host in a cluster
+func GetDatastoreInHost(vm *VM) ([]map[string]string, error) {
+	var (
+		datastoreList []map[string]string
+		datastore     mo.Datastore
+		hsMo          mo.HostSystem
+	)
 	// set up session to vcenter server
 	if err := SetupSession(vm); err != nil {
 		return nil, err
 	}
-	// get datacenter list in the vcenter server
-	dcList, err := vm.finder.DatacenterList(vm.ctx, "*")
+
+	// set up session to vcenter server
+	dc, err := GetDatacenter(vm)
 	if err != nil {
 		return nil, err
 	}
 
-	// for all datacenters in the vcenter server
-	for _, dc := range dcList {
-		// Set datacenter
-		vm.finder.SetDatacenter(dc)
-		// find the networks in selected datacenter
-		allNetworks, err := vm.finder.NetworkList(vm.ctx, "*")
+	// Get the cluster resource and its host, datastore and datastore
+	crMo, err := findClusterComputeResource(vm, dc, vm.Destination.DestinationName)
+	if err != nil {
+		return nil, err
+	}
+
+	// find the host in Destination.HostSystem
+	for _, host := range crMo.Host {
+		err = vm.collector.RetrieveOne(vm.ctx, host, []string{"name", "datastore"}, &hsMo)
 		if err != nil {
-			switch err.(type) {
-			case *find.NotFoundError:
-				networkList[dc.Name()] = []string{}
-				continue
-			}
 			return nil, err
 		}
-
-		var networksMor []types.ManagedObjectReference
-		for _, network := range allNetworks {
-			networksMor = append(networksMor, network.Reference())
+		if hsMo.Name == vm.Destination.HostSystem {
+			break
 		}
+	}
 
-		// get the network names
-		var network mo.Network
-		for _, networkMor := range networksMor {
-			switch networkMor.Type {
-			case "Network":
-				err = vm.collector.RetrieveOne(vm.ctx, networkMor, []string{"name"}, &network)
-				if err != nil {
-					return nil, err
-				}
-				networkList[dc.Name()] = append(networkList[dc.Name()], network.Name)
+	// Add all the datastores in host to datastore list
+	for _, datastoreMor := range hsMo.Datastore {
+		err = vm.collector.RetrieveOne(vm.ctx, datastoreMor, []string{"name", "summary"}, &datastore)
+		if err != nil {
+			return nil, err
+		}
+		datastoreList = append(datastoreList, map[string]string{
+			"name":      datastore.Name,
+			"capacity":  fmt.Sprintf("%d", datastore.Summary.Capacity),
+			"freespace": fmt.Sprintf("%d", datastore.Summary.FreeSpace),
+		})
+	}
+	return datastoreList, nil
+}
+
+// GetNetworkInHost : Returns the networks in a host in a cluster
+func GetNetworkInHost(vm *VM) ([]map[string]string, error) {
+	var (
+		networkList []map[string]string
+		networkMap  map[string]string
+		network     mo.Network
+		portGroup   mo.DistributedVirtualPortgroup
+		opNetwork   mo.OpaqueNetwork
+		hsMo        mo.HostSystem
+	)
+	// set up session to vcenter server
+	if err := SetupSession(vm); err != nil {
+		return nil, err
+	}
+
+	dc, err := GetDatacenter(vm)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the cluster resource and its host, network and datastore
+	crMo, err := findClusterComputeResource(vm, dc, vm.Destination.DestinationName)
+	if err != nil {
+		return nil, err
+	}
+
+	// find the host in Destination.HostSystem
+	for _, host := range crMo.Host {
+		err = vm.collector.RetrieveOne(vm.ctx, host, []string{"name", "network"}, &hsMo)
+		if err != nil {
+			return nil, err
+		}
+		if hsMo.Name == vm.Destination.HostSystem {
+			break
+		}
+	}
+
+	// Add all the networks in host to network list
+	for _, networkMor := range hsMo.Network {
+		switch networkMor.Type {
+		case "Network":
+			err = vm.collector.RetrieveOne(vm.ctx, networkMor, []string{"name"}, &network)
+			if err != nil {
+				return nil, err
+			}
+			networkMap = map[string]string{"name": network.Name}
+		case "DistributedVirtualPortgroup":
+			err = vm.collector.RetrieveOne(vm.ctx, networkMor, []string{"name"}, &portGroup)
+			if err != nil {
+				return nil, err
+			}
+			networkMap = map[string]string{"name": portGroup.Name}
+		case "OpaqueNetwork":
+			err = vm.collector.RetrieveOne(vm.ctx, networkMor, []string{"name"}, &opNetwork)
+			if err != nil {
+				return nil, err
+			}
+			networkMap = map[string]string{"name": opNetwork.Name}
+		}
+		networkList = append(networkList, networkMap)
+	}
+	return networkList, nil
+}
+
+// GetDcNetworkList : returns a list of network in given datacenter
+// available-filters (map-keys): "hosts", "clusters".
+func GetDcNetworkList(vm *VM, filter map[string][]string) ([]map[string]string, error) {
+	networkMap := map[string]bool{}
+	networks := []map[string]string{}
+	// set up session to vcenter server
+	if err := SetupSession(vm); err != nil {
+		return nil, err
+	}
+	if _, ok := filter["clusters"]; !ok {
+		return nil, errors.New("Key 'clusters' is missing")
+	}
+
+	if _, ok := filter["hosts"]; !ok {
+		return nil, errors.New("Key 'hosts' is missing")
+	}
+
+	vm.Destination.DestinationType = "cluster"
+	for _, cluster := range filter["clusters"] {
+		vm.Destination.DestinationName = cluster
+		for _, host := range filter["hosts"] {
+			vm.Destination.HostSystem = host
+			networksInHost, err := GetNetworkInHost(vm)
+			switch err.(type) {
+			case ErrorObjectNotFound:
+				continue
+			}
+			if err != nil {
+				return nil, err
+			}
+			for _, network := range networksInHost {
+				networkMap[network["name"]] = true
 			}
 		}
 	}
-	return networkList, nil
+	for k := range networkMap {
+		networks = append(networks, map[string]string{
+			"name": k,
+		})
+	}
+	return networks, nil
 }
 
 // GetDcImageList : GetDcImageList returns the list of images in
@@ -936,57 +1042,56 @@ func GetDcImageList(vm *VM) (map[string][]string, error) {
 	return imageList, nil
 }
 
-// GetDcClusterList : GetDcClusterList returns the datacenter and the clusters in the datacenter
-func GetDcClusterList(vm *VM) (map[string][]string, error) {
-	dcClusterList := map[string][]string{}
+// GetDcClusterList : GetDcClusterList returns the clusters in the datacenter
+func GetDcClusterList(vm *VM) ([]map[string]string, error) {
+	dcClusterList := []map[string]string{}
 	// setupSession
 	if err := SetupSession(vm); err != nil {
 		return nil, err
 	}
 
-	// get datacenter list in the vcenter server
-	dcList, err := vm.finder.DatacenterList(vm.ctx, "*")
+	// get datacenter in the vcenter server
+	dcMo, err := GetDatacenter(vm)
 	if err != nil {
 		return nil, err
 	}
 
-	// for all datacenters in the vcenter server
-	for _, dc := range dcList {
-		// Set datacenter
-		vm.finder.SetDatacenter(dc)
-		// find the clusters in selected datacenter
-		allClusters, err := vm.finder.ClusterComputeResourceList(vm.ctx, "*")
-		if err != nil {
-			switch err.(type) {
-			case *find.NotFoundError:
-				dcClusterList[dc.Name()] = []string{}
-				continue
-			}
-			return nil, err
+	dc := object.NewDatacenter(vm.client.Client, dcMo.Self)
+	// Set datacenter
+	vm.finder.SetDatacenter(dc)
+	// find the clusters in selected datacenter
+	allClusters, err := vm.finder.ClusterComputeResourceList(vm.ctx, "*")
+	if err != nil {
+		switch err.(type) {
+		case *find.NotFoundError:
+			return dcClusterList, nil
 		}
-		var clustersMor []types.ManagedObjectReference
-		for _, cluster := range allClusters {
-			clustersMor = append(clustersMor, cluster.Reference())
-		}
-		// get the cluster names
-		var allClustersMo []mo.ClusterComputeResource
-		err = vm.collector.Retrieve(vm.ctx, clustersMor, []string{"name"}, &allClustersMo)
-		if err != nil {
-			return nil, err
-		}
-		// generate response for the cluster in datacenter. In the response map
-		// the key is the datacenter name and value is the list of clusters in datacenter
-		for _, cluster := range allClustersMo {
-			dcClusterList[dc.Name()] = append(dcClusterList[dc.Name()], cluster.Name)
-		}
+		return nil, err
 	}
-	return dcClusterList, err
+	var clustersMor []types.ManagedObjectReference
+	for _, cluster := range allClusters {
+		clustersMor = append(clustersMor, cluster.Reference())
+	}
+	// get the cluster names
+	var allClustersMo []mo.ClusterComputeResource
+	err = vm.collector.Retrieve(vm.ctx, clustersMor, []string{"name"}, &allClustersMo)
+	if err != nil {
+		return nil, err
+	}
+	// generate response for the cluster in datacenter. In the response map
+	// the key is the datacenter name and value is the list of clusters in datacenter
+	for _, cluster := range allClustersMo {
+		dcClusterList = append(dcClusterList, map[string]string{
+			"name": cluster.Name,
+		})
+	}
+	return dcClusterList, nil
 }
 
 // GetDatacenterList : return the list of datacenters in vcenter server
-func GetDatacenterList(vm *VM) ([]string, error) {
+func GetDatacenterList(vm *VM) ([]map[string]string, error) {
 	var (
-		dcList  []string
+		dcList  []map[string]string
 		dcMor   []types.ManagedObjectReference
 		allDcMo []mo.Datacenter
 	)
@@ -1017,16 +1122,18 @@ func GetDatacenterList(vm *VM) ([]string, error) {
 	}
 
 	for _, dc := range allDcMo {
-		dcList = append(dcList, dc.Name)
+		dcList = append(dcList, map[string]string{
+			"name": dc.Name,
+		})
 	}
 
 	return dcList, nil
 }
 
 // GetHosts : returns the hosts in a cluster in vcenter server
-func GetHostList(vm *VM) ([]string, error) {
+func GetHostList(vm *VM) ([]map[string]string, error) {
 	var (
-		hostList []string
+		hostList []map[string]string
 		hsMo     mo.HostSystem
 	)
 	// set up session to vcenter server
@@ -1052,7 +1159,9 @@ func GetHostList(vm *VM) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		hostList = append(hostList, hsMo.Name)
+		hostList = append(hostList, map[string]string{
+			"name": hsMo.Name,
+		})
 	}
 
 	return hostList, nil


### PR DESCRIPTION
**Jira ID**

C3-254
C3-253

**Description**
Changes done
Support for get_network_list call with filter (cluster and host level filter) is added
Support for get_datastore_list call which returns the hosts in a cluster is added
Updated the response of get_custer_list, get_datacenter_list and get_host_list call

**Testing**

Done. Logs below:

[root@localhost test]# go run vsphereclient.go
Datastore in a hostsystem :
[{"capacity":"992137445376","freespace":"216217419776","name":"datastore1"},{"capacity":"2000112582656","freespace":"1971742310400","name":"Datastore-ESXi5-2TB"}]


[root@localhost test]# go run vsphereclient.go
Networks in a hostsystem :
[{"name":"VM Network"},{"name":"VMprivate-network"},{"name":"visor_network"}]



[root@localhost test]# go run vsphereclient.go
Networks in a datacenter as per filter :
[{"name":"VM Network"},{"name":"VMprivate-network"},{"name":"visor_network"},{"name":"VM-private-net2"}]


[root@localhost test]# go run vsphereclient.go 
Clusters in a datacenter : 
[{"name":"C3 Cluster-1"}]

[root@localhost test]# go run vsphereclient.go 
Datacenter List :
[{"name":"Jignesh-DataCenter"},{"name":"DETA-Lab"},{"name":"C3 DataCenter"},{"name":"pinkesh-lab"}]


[root@localhost test]# go run vsphereclient.go 
Host in a cluster:
[{"name":"67.220.182.194"},{"name":"67.220.182.195"},{"name":"209.205.216.2"},{"name":"209.205.217.242"}]