### PR TITLE
C3-275 : Update the vm template creation logic in libretto

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -495,9 +495,11 @@ var cloneFromTemplate = func(vm *VM, dcMo *mo.Datacenter, usableDatastores []str
 		return err
 	}
 	dsMor := dsMo.Reference()
-	template := vm.Template
+	var template string
 	if vm.UseLocalTemplates {
 		template = createTemplateName(vm.Template, vm.datastore)
+	} else {
+		template = vm.Template
 	}
 	vmMo, err := findVM(vm, dcMo, template)
 	if err != nil {
@@ -824,9 +826,11 @@ var createTemplateName = func(t string, ds string) string {
 }
 
 var uploadTemplate = func(vm *VM, dcMo *mo.Datacenter, selectedDatastore string) error {
-	template := vm.Template
+	var template string
 	if vm.UseLocalTemplates {
 		template = createTemplateName(vm.Template, selectedDatastore)
+	} else {
+		template = vm.Template
 	}
 	vm.datastore = selectedDatastore
 	downloadOvaPath, err := ioutil.TempDir("", "")

--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -495,7 +495,10 @@ var cloneFromTemplate = func(vm *VM, dcMo *mo.Datacenter, usableDatastores []str
 		return err
 	}
 	dsMor := dsMo.Reference()
-	template := createTemplateName(vm.Template, vm.datastore)
+	template := vm.Template
+	if vm.UseLocalTemplates {
+		template = createTemplateName(vm.Template, vm.datastore)
+	}
 	vmMo, err := findVM(vm, dcMo, template)
 	if err != nil {
 		return fmt.Errorf("error retrieving template: %s", err)
@@ -821,7 +824,10 @@ var createTemplateName = func(t string, ds string) string {
 }
 
 var uploadTemplate = func(vm *VM, dcMo *mo.Datacenter, selectedDatastore string) error {
-	template := createTemplateName(vm.Template, selectedDatastore)
+	template := vm.Template
+	if vm.UseLocalTemplates {
+		template = createTemplateName(vm.Template, selectedDatastore)
+	}
 	vm.datastore = selectedDatastore
 	downloadOvaPath, err := ioutil.TempDir("", "")
 	if err != nil {

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -434,9 +434,11 @@ func (vm *VM) Provision() (err error) {
 
 	usableDatastores := []string{}
 	for _, d := range datastores {
-		template := vm.Template
+		var template string
 		if vm.UseLocalTemplates {
 			template = createTemplateName(vm.Template, d)
+		} else {
+			template = vm.Template
 		}
 		// Does the VM template already exist?
 		e, err := Exists(vm, dcMo, template)

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -434,7 +434,10 @@ func (vm *VM) Provision() (err error) {
 
 	usableDatastores := []string{}
 	for _, d := range datastores {
-		template := createTemplateName(vm.Template, d)
+		template := vm.Template
+		if vm.UseLocalTemplates {
+			template = createTemplateName(vm.Template, d)
+		}
 		// Does the VM template already exist?
 		e, err := Exists(vm, dcMo, template)
 		if err != nil {
@@ -792,6 +795,24 @@ func (vm *VM) GetSSH(options ssh.Options) (ssh.Client, error) {
 	return &client, nil
 }
 
+func deleteVM(vm *VM, vmMor *mo.VirtualMachine) error {
+	// create vm object for found vm-template and calls destroy function on the vm
+	vmo := object.NewVirtualMachine(vm.client.Client, vmMor.Reference())
+	task, err := vmo.Destroy(vm.ctx)
+	if err != nil {
+		return err
+	}
+	// wait for the task to complete and checks for the errors if any
+	tInfo, err := task.WaitForResult(vm.ctx, nil)
+	if err != nil {
+		return fmt.Errorf("Error waiting for task : %s", err)
+	}
+	if tInfo.Error != nil {
+		return fmt.Errorf("Destroy task returned error : %s", tInfo.Error)
+	}
+	return nil
+}
+
 // DeleteTemplate deletes the vm-template, created during vm provisioning
 func DeleteTemplate(vm *VM) error {
 	// for the templates that do not exist in server
@@ -804,6 +825,14 @@ func DeleteTemplate(vm *VM) error {
 		return fmt.Errorf("Failed to retrieve datacenter: %s", err)
 	}
 	// find and delete vm-templates from all provided datastores
+	if !vm.UseLocalTemplates {
+		vmMo, err := findVM(vm, dcMo, vm.Template)
+		if err != nil {
+			return err
+		}
+		err = deleteVM(vm, vmMo)
+		return err
+	}
 	for _, datastore := range vm.Datastores {
 		// generate template name <provided-name>-<datastore-name>
 		template := createTemplateName(vm.Template, datastore)
@@ -814,19 +843,9 @@ func DeleteTemplate(vm *VM) error {
 			missingTemplates = append(missingTemplates, template)
 			continue
 		}
-		// create vm object for found vm-template and calls destroy function on the vm
-		vmo := object.NewVirtualMachine(vm.client.Client, templateVm.Reference())
-		task, err := vmo.Destroy(vm.ctx)
+		err = deleteVM(vm, templateVm)
 		if err != nil {
 			return err
-		}
-		// wait for the task to complete and checks for the errors if any
-		tInfo, err := task.WaitForResult(vm.ctx, nil)
-		if err != nil {
-			return fmt.Errorf("Error waiting for task : %s", err)
-		}
-		if tInfo.Error != nil {
-			return fmt.Errorf("Destroy task returned error : %s", tInfo.Error)
 		}
 	}
 	//  If there are any missing templates, return error


### PR DESCRIPTION
**Jira Id**

C3-275

**Problem**

Currently the datastore is appended to the vm template name and then it is created. The logic to create the vm template name needs to be modified, appending the datastore name is not required.
Same needs to be updated in deleteTemplate call.

**Solution**

Removed the logic to append the datastore name to vm.Template
Removed UseLocalClones field from VM structure

**Unit Testing**

Done
Creating Vm with the new template and existing template [OK]
Overwriting the template [OK]
Deleting the template [OK]