### PR TITLE
C3-142 : Issue while creating private network

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -281,12 +281,12 @@ var createNetworkMapping = func(vm *VM, networks map[string]string, networkMors 
 	}
 
 	var mappings []types.OvfNetworkMapping
-	for network, mapping := range networks {
+	for _, mapping := range networks {
 		mor, ok := nwMap[mapping]
 		if !ok {
 			return nil, NewErrorObjectNotFound(errors.New("Could not find the network mapping"), mapping)
 		}
-		mappings = append(mappings, types.OvfNetworkMapping{Name: network, Network: mor})
+		mappings = append(mappings, types.OvfNetworkMapping{Name: mapping, Network: mor})
 	}
 	return mappings, nil
 }


### PR DESCRIPTION
**Jira-Id**

C3-142

**Problem**

The network device is not connected to the vm if the key - value in the network field in vm struct is different.

**Resolution**

Sent the value in network map as the device name

**Testing**

Done.

Tried creating vm with the below scenarios:

(Key : Value)
("VM Network":"VM Network") = "VM created with the network 'VM Network' IP assigned to vm"
("Random string": "VM Network") = "VM created with the network 'VM Network' IP assigned to vm"
("Random string": "Dev Network") = "VM created with the network 'Dev Network' IP assigned to vm"
("Random string": "Random str") = "Error out 'Invalid network'"