### PR TITLE
C3-465: Collect stats for vcenter objects datastore, hostsystem, clusterComputeResource

### DIFF
--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -90,6 +90,103 @@ func (v VMwareLease) Complete() error {
 	return v.Lease.HttpNfcLeaseComplete(v.Ctx)
 }
 
+type Datastore struct {
+	Name            string `json:"name"`
+	Type            string `json:"type"`
+	Url             string `json:"url"`
+	VirtualCapacity int64  `json:"virtual_capacity"`
+	Capacity        int64  `json:"capacity"`
+	FreeSpace       int64  `json:"free_space"`
+}
+
+func (ds *Datastore) init(dsMo mo.Datastore) {
+	ds.Name = dsMo.Name
+	ds.Type = dsMo.Summary.Type
+	ds.Url = dsMo.Summary.Url
+	ds.FreeSpace = dsMo.Summary.FreeSpace
+	ds.Capacity = dsMo.Summary.Capacity
+	info := dsMo.Info
+	if info != nil && info.GetDatastoreInfo() != nil {
+		ds.VirtualCapacity = info.GetDatastoreInfo().MaxVirtualDiskCapacity
+	}
+}
+
+type HostSystem struct {
+	Name            string      `json:"name"`
+	CpuModel        string      `json:"cpu_model"`
+	NumCpuPkgs      int16       `json:"num_cpu_pkgs"`
+	NumCpuCores     int16       `json:"num_cpu_cores"`
+	TotalCpu        int32       `json:"total_cpu"`
+	FreeCpu         int32       `json:"free_cpu"`
+	TotalMemory     int64       `json:"total_memory"`
+	FreeMemory      int64       `json:"free_memory"`
+	TotalStorage    int64       `json:"total_storage"`
+	FreeStorage     int64       `json:"free_storage"`
+	VirtualCapacity int64       `json:"virtual_capacity"`
+	Datastores      []Datastore `json:"datastores"`
+}
+
+func (hs *HostSystem) init(hsMo mo.HostSystem, datastores []Datastore) {
+	hs.Name = hsMo.Name
+	hs.Datastores = datastores
+	for _, ds := range hs.Datastores {
+		hs.TotalStorage += ds.Capacity
+		hs.FreeStorage += ds.FreeSpace
+	}
+	hs.VirtualCapacity = hsMo.Runtime.HostMaxVirtualDiskCapacity
+	hs.NumCpuCores = hsMo.Summary.Hardware.NumCpuCores
+	hs.TotalCpu = int32(hs.NumCpuCores) * hsMo.Summary.Hardware.CpuMhz
+	hs.CpuModel = hsMo.Summary.Hardware.CpuModel
+	hs.NumCpuPkgs = hsMo.Summary.Hardware.NumCpuPkgs
+	hs.TotalMemory = hsMo.Summary.Hardware.MemorySize
+
+	// runtime info
+	hs.FreeCpu = int32(hs.TotalCpu) - hsMo.Summary.QuickStats.OverallCpuUsage
+	hs.FreeMemory = hs.TotalMemory - int64(hsMo.Summary.QuickStats.OverallMemoryUsage)*1024*1024
+}
+
+type ClusterComputeResource struct {
+	Name           string       `json:"name"`
+	NumCpuCores    int16        `json:"num_cpu_cores"`
+	NumCpuThreads  int16        `json:"num_cpu_threads"`
+	TotalCpu       int32        `json:"total_cpu"`
+	FreeCpu        int32        `json:"free_cpu"`
+	TotalMemory    int64        `json:"total_memory"`
+	FreeMemory     int64        `json:"free_memory"`
+	TotalStorage   int64        `json:"total_storage"`
+	FreeStorage    int64        `json:"free_storage"`
+	NoOfHosts      int          `json:"number_of_hosts"`
+	NoOfDatastores int          `json:"number_of_datastores"`
+	NoOfNetworks   int          `json:"number_of_networks"`
+	Hosts          []HostSystem `json:"hosts"`
+}
+
+func (cr *ClusterComputeResource) init(crMo mo.ClusterComputeResource, hosts []HostSystem) {
+	cr.Name = crMo.Name
+	cr.Hosts = hosts
+	cr.TotalCpu = crMo.Summary.GetComputeResourceSummary().TotalCpu
+	cr.TotalMemory = crMo.Summary.GetComputeResourceSummary().TotalMemory
+	cr.NumCpuCores = crMo.Summary.GetComputeResourceSummary().NumCpuCores
+	cr.NumCpuThreads = crMo.Summary.GetComputeResourceSummary().NumCpuThreads
+	cr.NoOfHosts = len(crMo.Host)
+	cr.NoOfDatastores = len(crMo.Datastore)
+	cr.NoOfNetworks = len(crMo.Network)
+	m := make(map[string]bool)
+	for _, host := range cr.Hosts {
+		for _, ds := range host.Datastores {
+			_, ok := m[ds.Name]
+			if ok {
+				continue
+			}
+			m[ds.Name] = true
+			cr.TotalStorage += ds.Capacity
+			cr.FreeStorage += ds.FreeSpace
+		}
+		cr.FreeCpu += host.FreeCpu
+		cr.FreeMemory += host.FreeMemory
+	}
+}
+
 // NewProgressReader returns a functional instance of ReadProgress.
 var NewProgressReader = func(r io.Reader, t int64, l Lease) ProgressReader {
 	return ReadProgress{
@@ -858,12 +955,12 @@ func DeleteTemplate(vm *VM) error {
 }
 
 // GetDatastoreInHost : Returns the datastores in a host in a cluster
-func GetDatastoreInHost(vm *VM) ([]map[string]string, error) {
+func GetDatastoreInHost(vm *VM) ([]Datastore, error) {
 	var (
-		datastore mo.Datastore
-		hsMo      mo.HostSystem
+		datastore     mo.Datastore
+		hsMo          mo.HostSystem
+		datastoreList []Datastore
 	)
-	datastoreList := make([]map[string]string, 0)
 	// set up session to vcenter server
 	if err := SetupSession(vm); err != nil {
 		return nil, err
@@ -894,15 +991,13 @@ func GetDatastoreInHost(vm *VM) ([]map[string]string, error) {
 
 	// Add all the datastores in host to datastore list
 	for _, datastoreMor := range hsMo.Datastore {
-		err = vm.collector.RetrieveOne(vm.ctx, datastoreMor, []string{"name", "summary"}, &datastore)
+		err = vm.collector.RetrieveOne(vm.ctx, datastoreMor, []string{"name", "summary", "info", "vm"}, &datastore)
 		if err != nil {
 			return nil, err
 		}
-		datastoreList = append(datastoreList, map[string]string{
-			"name":      datastore.Name,
-			"capacity":  fmt.Sprintf("%d", datastore.Summary.Capacity),
-			"freespace": fmt.Sprintf("%d", datastore.Summary.FreeSpace),
-		})
+		ds := Datastore{}
+		ds.init(datastore)
+		datastoreList = append(datastoreList, ds)
 	}
 	return datastoreList, nil
 }
@@ -993,11 +1088,12 @@ func GetDcNetworkList(vm *VM, filter map[string][]string) ([]map[string]string, 
 	var (
 		clusters []string
 		hosts    []string
+		err      error
 	)
 
 	networks := make([]map[string]string, 0)
 	// set up session to vcenter server
-	if err := SetupSession(vm); err != nil {
+	if err = SetupSession(vm); err != nil {
 		return nil, err
 	}
 	clusters, ok := filter["clusters"]
@@ -1023,7 +1119,7 @@ func GetDcNetworkList(vm *VM, filter map[string][]string) ([]map[string]string, 
 		}
 		hostList := make([]string, 0)
 		for _, host := range hostsInCluster {
-			hostList = append(hostList, host["name"])
+			hostList = append(hostList, host.Name)
 		}
 		for _, host := range hosts {
 			if StringInSlice(host, hostList) {
@@ -1107,8 +1203,10 @@ func GetDcImageList(vm *VM) (map[string][]string, error) {
 }
 
 // GetDcClusterList : GetDcClusterList returns the clusters in the datacenter
-func GetDcClusterList(vm *VM) ([]map[string]string, error) {
-	dcClusterList := []map[string]string{}
+func GetDcClusterList(vm *VM) ([]ClusterComputeResource, error) {
+	var (
+		dcClusterList []ClusterComputeResource
+	)
 	// setupSession
 	if err := SetupSession(vm); err != nil {
 		return nil, err
@@ -1138,16 +1236,20 @@ func GetDcClusterList(vm *VM) ([]map[string]string, error) {
 	}
 	// get the cluster names
 	var allClustersMo []mo.ClusterComputeResource
-	err = vm.collector.Retrieve(vm.ctx, clustersMor, []string{"name"}, &allClustersMo)
+	err = vm.collector.Retrieve(vm.ctx, clustersMor, []string{"name", "summary", "host", "datastore", "network"}, &allClustersMo)
 	if err != nil {
 		return nil, err
 	}
 	// generate response for the cluster in datacenter. In the response map
 	// the key is the datacenter name and value is the list of clusters in datacenter
 	for _, cluster := range allClustersMo {
-		dcClusterList = append(dcClusterList, map[string]string{
-			"name": cluster.Name,
-		})
+		cr := ClusterComputeResource{}
+		hosts, err := GetHostList(vm)
+		if err != nil {
+			return nil, err
+		}
+		cr.init(cluster, hosts)
+		dcClusterList = append(dcClusterList, cr)
 	}
 	return dcClusterList, nil
 }
@@ -1194,12 +1296,12 @@ func GetDatacenterList(vm *VM) ([]map[string]string, error) {
 	return dcList, nil
 }
 
-// GetHosts : returns the hosts in a cluster in vcenter server
-func GetHostList(vm *VM) ([]map[string]string, error) {
+// GetHostList : returns the hosts in a cluster in vcenter server
+func GetHostList(vm *VM) ([]HostSystem, error) {
 	var (
-		hsMo mo.HostSystem
+		hsMo     mo.HostSystem
+		hostList []HostSystem
 	)
-	hostList := make([]map[string]string, 0)
 	// set up session to vcenter server
 	if err := SetupSession(vm); err != nil {
 		return nil, err
@@ -1219,13 +1321,18 @@ func GetHostList(vm *VM) ([]map[string]string, error) {
 	}
 	// get the host list in datacenter vm.Datacenter
 	for _, host := range crMo.Host {
-		err := vm.collector.RetrieveOne(vm.ctx, host, []string{"name"}, &hsMo)
+		err := vm.collector.RetrieveOne(vm.ctx, host, []string{"name", "summary", "runtime"}, &hsMo)
 		if err != nil {
 			return nil, err
 		}
-		hostList = append(hostList, map[string]string{
-			"name": hsMo.Name,
-		})
+		hs := HostSystem{}
+		vm.Destination.HostSystem = hsMo.Name
+		datastores, err := GetDatastoreInHost(vm)
+		if err != nil {
+			return nil, err
+		}
+		hs.init(hsMo, datastores)
+		hostList = append(hostList, hs)
 	}
 
 	return hostList, nil


### PR DESCRIPTION
**Jira ID**

C3-465

**Problem**

Collect stats for vcenter objects datastore, hostsystem, clusterComputeResource

**Solution**

Collected stats for datastore, hostsystem, clusterComputeResource and sent in the response for get calls for the specific objects.

**Unit Testing**

Done. Logs below:

```
Datastore-list:-
[root@my_machine test]# go run vsphereclient.go
[{"name":"datastore1-ESXi13-120GB","type":"VMFS","url":"ds:///vmfs/volumes/58d3c63d-58e65c3c-5a0c-002590e9abe6/","virtual_capacity":68169720922112,"capacity":248034361344,"free_space":146605604864,"ssd":true,"local":true,"scsi_disk_type":"","multiple_host_access":false,"accessible":true},{"name":"datastore2-ESXi13-2TB","type":"VMFS","url":"ds:///vmfs/volumes/58d526ee-01a2153e-765a-002590e9abe6/","virtual_capacity":68169720922112,"capacity":2000112582656,"free_space":461985808384,"ssd":false,"local":true,"scsi_disk_type":"","multiple_host_access":false,"accessible":true}]

Hostsystem-list:-
[{"name":"67.220.186.4","cpu_model":"Intel(R) Xeon(R) CPU E3-1230 v3 @ 3.30GHz","num_cpu_pkgs":1,"num_cpu_cores":4,"total_cpu":13196,"free_cpu":10477,"total_memory":34316492800,"free_memory":3944488960,"total_storage":2248146944000,"free_storage":608591413248,"virtual_capacity":68169720922112,"datastores":[{"name":"datastore1-ESXi13-120GB","type":"VMFS","url":"ds:///vmfs/volumes/58d3c63d-58e65c3c-5a0c-002590e9abe6/","virtual_capacity":68169720922112,"capacity":248034361344,"free_space":146605604864,"ssd":true,"local":true,"scsi_disk_type":"","multiple_host_access":false,"accessible":true},{"name":"datastore2-ESXi13-2TB","type":"VMFS","url":"ds:///vmfs/volumes/58d526ee-01a2153e-765a-002590e9abe6/","virtual_capacity":68169720922112,"capacity":2000112582656,"free_space":461985808384,"ssd":false,"local":true,"scsi_disk_type":"","multiple_host_access":false,"accessible":true}]}]


Cluster-List:-
[{"name":"C3 Cluster-1","num_cpu_cores":4,"num_cpu_threads":8,"total_cpu":13196,"free_cpu":10477,"total_memory":34316492800,"free_memory":3944488960,"total_storage":2248146944000,"free_storage":608591413248,"number_of_hosts":1,"number_of_datastores":2,"number_of_networks":3,"hosts":[{"name":"67.220.186.4","cpu_model":"Intel(R) Xeon(R) CPU E3-1230 v3 @ 3.30GHz","num_cpu_pkgs":1,"num_cpu_cores":4,"total_cpu":13196,"free_cpu":10477,"total_memory":34316492800,"free_memory":3944488960,"total_storage":2248146944000,"free_storage":608591413248,"virtual_capacity":68169720922112,"datastores":[{"name":"datastore1-ESXi13-120GB","type":"VMFS","url":"ds:///vmfs/volumes/58d3c63d-58e65c3c-5a0c-002590e9abe6/","virtual_capacity":68169720922112,"capacity":248034361344,"free_space":146605604864,"ssd":true,"local":true,"scsi_disk_type":"","multiple_host_access":false,"accessible":true},{"name":"datastore2-ESXi13-2TB","type":"VMFS","url":"ds:///vmfs/volumes/58d526ee-01a2153e-765a-002590e9abe6/","virtual_capacity":68169720922112,"capacity":2000112582656,"free_space":461985808384,"ssd":false,"local":true,"scsi_disk_type":"","multiple_host_access":false,"accessible":true}]}]}]
[root@my_machine test]#
```