### PR TITLE
C3-465: Collect stats for clusterComputeResource, issue with get cluster list

### DIFF
--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -1264,6 +1264,10 @@ func GetDcClusterList(vm *VM) ([]ClusterComputeResource, error) {
 	// the key is the datacenter name and value is the list of clusters in datacenter
 	for _, cluster := range allClustersMo {
 		cr := ClusterComputeResource{}
+		vm.Destination = Destination{
+			DestinationType: "cluster",
+			DestinationName: cluster.Name,
+		}
 		hosts, err := GetHostList(vm)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
**Jira ID**

C3-465

**Problem**

Collect stats for vcenter objects datastore, hostsystem, clusterComputeResource. Issue with get cluster list. The cluster is not called before calling get host list from get cluster list operation which causes error.

**Solution**

Set the cluster name before calling get host list.

**Unit Testing**

Done. Logs below:

```
[root@my_machine test]# go run vsphereclient.go
Cluster-list:-
[{"name":"C3 Cluster-1","num_cpu_cores":4,"num_cpu_threads":8,"total_cpu":13196,"free_cpu":11753,"total_memory":34316492800,"free_memory":14831853568,"total_storage":2248146944000,"free_storage":1102333345792,"number_of_hosts":1,"number_of_datastores":2,"number_of_networks":3,"hosts":[{"name":"67.220.186.4","cpu_model":"Intel(R) Xeon(R) CPU E3-1230 v3 @ 3.30GHz","num_cpu_pkgs":1,"num_cpu_cores":4,"total_cpu":13196,"free_cpu":11753,"total_memory":34316492800,"free_memory":14831853568,"total_storage":2248146944000,"free_storage":1102333345792,"virtual_capacity":68169720922112,"datastores":[{"name":"datastore1-ESXi13-120GB","type":"VMFS","url":"ds:///vmfs/volumes/58d3c63d-58e65c3c-5a0c-002590e9abe6/","virtual_capacity":68169720922112,"capacity":248034361344,"free_space":245586984960,"ssd":true,"local":true,"scsi_disk_type":"","multiple_host_access":false,"accessible":true},{"name":"datastore2-ESXi13-2TB","type":"VMFS","url":"ds:///vmfs/volumes/58d526ee-01a2153e-765a-002590e9abe6/","virtual_capacity":68169720922112,"capacity":2000112582656,"free_space":856746360832,"ssd":false,"local":true,"scsi_disk_type":"","multiple_host_access":false,"accessible":true}]}]}]

HostSystem-list:-
[{"name":"67.220.186.4","cpu_model":"Intel(R) Xeon(R) CPU E3-1230 v3 @ 3.30GHz","num_cpu_pkgs":1,"num_cpu_cores":4,"total_cpu":13196,"free_cpu":11753,"total_memory":34316492800,"free_memory":14831853568,"total_storage":2248146944000,"free_storage":1102333345792,"virtual_capacity":68169720922112,"datastores":[{"name":"datastore1-ESXi13-120GB","type":"VMFS","url":"ds:///vmfs/volumes/58d3c63d-58e65c3c-5a0c-002590e9abe6/","virtual_capacity":68169720922112,"capacity":248034361344,"free_space":245586984960,"ssd":true,"local":true,"scsi_disk_type":"","multiple_host_access":false,"accessible":true},{"name":"datastore2-ESXi13-2TB","type":"VMFS","url":"ds:///vmfs/volumes/58d526ee-01a2153e-765a-002590e9abe6/","virtual_capacity":68169720922112,"capacity":2000112582656,"free_space":856746360832,"ssd":false,"local":true,"scsi_disk_type":"","multiple_host_access":false,"accessible":true}]}]

Datastore-list:-
[{"name":"datastore1-ESXi13-120GB","type":"VMFS","url":"ds:///vmfs/volumes/58d3c63d-58e65c3c-5a0c-002590e9abe6/","virtual_capacity":68169720922112,"capacity":248034361344,"free_space":245586984960,"ssd":true,"local":true,"scsi_disk_type":"","multiple_host_access":false,"accessible":true},{"name":"datastore2-ESXi13-2TB","type":"VMFS","url":"ds:///vmfs/volumes/58d526ee-01a2153e-765a-002590e9abe6/","virtual_capacity":68169720922112,"capacity":2000112582656,"free_space":856746360832,"ssd":false,"local":true,"scsi_disk_type":"","multiple_host_access":false,"accessible":true}]

[root@my_machine test]#
```