### PR TITLE
MRPHS-2769 Enhancing vmWare fetch APIs for infra VM support

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -97,7 +97,7 @@ func GetDatacenter(vm *VM) (*mo.Datacenter, error) {
 	}
 	for _, dc := range dcList {
 		dcMo := mo.Datacenter{}
-		ps := []string{"name", "hostFolder", "vmFolder", "datastore"}
+		ps := []string{"name", "hostFolder", "vmFolder", "datastore", "network"}
 		err := vm.collector.RetrieveOne(vm.ctx, dc.Reference(), ps, &dcMo)
 		if err != nil {
 			return nil, NewErrorPropertyRetrieval(dc.Reference(), ps, err)

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -1128,17 +1128,12 @@ func getNetworks(vm *VM, networkMo []types.ManagedObjectReference) ([]map[string
 // GetDcNetworkList : returns a list of network in given datacenter
 // available-filters (map-keys): "hosts", "clusters".
 func GetDcNetworkList(vm *VM, filter map[string][]string) ([]map[string]string, error) {
-	filterExists := true
-
 	// set up session to vcenter server
 	if err := SetupSession(vm); err != nil {
 		return nil, err
 	}
 
-	clusters, ok := filter["clusters"]
-	if !ok {
-		filterExists = false
-	}
+	clusters, filterExists := filter["clusters"]
 	if !filterExists || len(clusters) == 0 {
 		// get datacenter in the vcenter server
 		dcMo, err := GetDatacenter(vm)
@@ -1357,7 +1352,7 @@ func GetDatacenterList(vm *VM) ([]map[string]string, error) {
 	for _, dc := range allDcMo {
 		dcList = append(dcList, map[string]string{
 			"name": dc.Name,
-			"id": dc.Self.Value,
+			"id":   dc.Self.Value,
 		})
 	}
 
@@ -1429,7 +1424,7 @@ func CreateTemplate(vm *VM) error {
 	return err
 }
 
-// GetDatastores : Returns the datastores in a host/cluster in a cluster
+// GetTemplateList : Returns the template VMs in a cluster
 func GetTemplateList(vm *VM) ([]map[string]string, error) {
 	vmMoList, err := getVirtualMachines(vm)
 	if err != nil {
@@ -1452,9 +1447,9 @@ func GetTemplateList(vm *VM) ([]map[string]string, error) {
 // GetVirtualMachines : Return the virual machines in a cluster
 func getVirtualMachines(vm *VM) ([]mo.VirtualMachine, error) {
 	var (
-		vmList			[]mo.VirtualMachine
-		virtualMachines	[]mo.VirtualMachine
-		hsMo          	mo.HostSystem
+		vmList          []mo.VirtualMachine
+		virtualMachines []mo.VirtualMachine
+		hsMo            mo.HostSystem
 	)
 	// set up session to vcenter server
 	if err := SetupSession(vm); err != nil {

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -1299,7 +1299,7 @@ func GetDcClusterList(vm *VM) ([]ClusterComputeResource, error) {
 	}
 	// get the cluster names
 	var allClustersMo []mo.ClusterComputeResource
-	err = vm.collector.Retrieve(vm.ctx, clustersMor, []string{"name", "summary", "host", "datastore", "network"}, &allClustersMo)
+	err = vm.collector.Retrieve(vm.ctx, clustersMor, []string{"name", "summary", "configuration", "host", "datastore", "network"}, &allClustersMo)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
[MRPHS-2769](https://apporbit.atlassian.net/browse/MRPHS-2769)

### Description:
Adding support for new APIs and modifying existing ones for Infra VM

### Resolution:
1. Get datastores for a cluster (no Host specified)
2. Get networks in a Datacenter/Cluster
3. Get list of VMs which are marked as templates
4. Return datacenter IDs along with names in GetDatacenters()

### Order of reviewing
n/a

### Testing:

**Unit Testing:**
Tested enhancements to existing APIs and new APIs using c3ntry_client and also by invoking controller APIs which call c3ntry APIs

**Automated testing:**
