### PR TITLE
MRPHS-2769 Returning VM Id in create-vm response

### DIFF
--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -702,20 +702,20 @@ func (vm *VM) RemoveDisk(vmdkFiles []string) error {
 
 // GetIPs returns the IPs and ref. Id of this VM. Returns all the IPs known to the API for
 // the different network cards for this VM. Includes IPV4 and IPV6 addresses.
-func (vm *VM) GetIPs() ([]net.IP, string, error) {
+func (vm *VM) GetIPsAndId() ([]net.IP, string, error) {
 	if err := SetupSession(vm); err != nil {
-		return nil, nil, err
+		return nil, "", err
 	}
 	defer vm.cancel()
 
 	// Get a reference to the datacenter with host and vm folders populated
 	dcMo, err := GetDatacenter(vm)
 	if err != nil {
-		return nil, nil, err
+		return nil, "", err
 	}
 	vmMo, err := findVM(vm, dcMo, vm.Name)
 	if err != nil {
-		return nil, nil, err
+		return nil, "", err
 	}
 	// Lazy initialized when there is an IP address later.
 	var ips []net.IP
@@ -738,6 +738,13 @@ func (vm *VM) GetIPs() ([]net.IP, string, error) {
 		}
 	}
 	return ips, vmMo.Self.Value, nil
+}
+
+// GetIPs returns the IPs of this VM. Returns all the IPs known to the API for
+// the different network cards for this VM. Includes IPV4 and IPV6 addresses.
+func (vm *VM) GetIPs() ([]net.IP, error) {
+	ips, _, err := vm.GetIPsAndId()
+	return ips, err
 }
 
 // Destroy deletes this VM from vSphere.

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -700,7 +700,7 @@ func (vm *VM) RemoveDisk(vmdkFiles []string) error {
 	return nil
 }
 
-// GetIPs returns the IPs and ref. Id of this VM. Returns all the IPs known to the API for
+// GetIPsAndId returns the IPs and reference Id of this VM. Returns all the IPs known to the API for
 // the different network cards for this VM. Includes IPV4 and IPV6 addresses.
 func (vm *VM) GetIPsAndId() ([]net.IP, string, error) {
 	if err := SetupSession(vm); err != nil {

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -700,22 +700,22 @@ func (vm *VM) RemoveDisk(vmdkFiles []string) error {
 	return nil
 }
 
-// GetIPs returns the IPs of this VM. Returns all the IPs known to the API for
+// GetIPs returns the IPs and ref. Id of this VM. Returns all the IPs known to the API for
 // the different network cards for this VM. Includes IPV4 and IPV6 addresses.
-func (vm *VM) GetIPs() ([]net.IP, error) {
+func (vm *VM) GetIPs() ([]net.IP, string, error) {
 	if err := SetupSession(vm); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer vm.cancel()
 
 	// Get a reference to the datacenter with host and vm folders populated
 	dcMo, err := GetDatacenter(vm)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	vmMo, err := findVM(vm, dcMo, vm.Name)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	// Lazy initialized when there is an IP address later.
 	var ips []net.IP
@@ -737,7 +737,7 @@ func (vm *VM) GetIPs() ([]net.IP, error) {
 			ips = append(ips, ip)
 		}
 	}
-	return ips, nil
+	return ips, vmMo.Self.Value, nil
 }
 
 // Destroy deletes this VM from vSphere.


### PR DESCRIPTION
[MRPHS-2769](https://apporbit.atlassian.net/browse/MRPHS-2769)

### Description:
VM id is required in response of create_vms call for supporting infra VMs

### Resolution:
Returning VM id along with IPs

### Order of reviewing
n/a

### Testing:

**Unit Testing:**
Tested enhancements to existing APIs and new APIs using c3ntry_client

**Automated testing:**
