### PR TITLE
MRPHS-2772 Adding support to fetch templates for a DC

### DIFF
--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -1467,7 +1467,7 @@ func GetTemplateList(vm *VM) ([]map[string]string, error) {
 	return vmList, nil
 }
 
-// GetVirtualMachines : Return the virtual machines in a cluster
+// getVirtualMachines : Return the virtual machines in a cluster
 func getVirtualMachines(vm *VM) ([]mo.VirtualMachine, error) {
 	var (
 		vmList          []mo.VirtualMachine


### PR DESCRIPTION
[MRPHS-2772](https://apporbit.atlassian.net/browse/MRPHS-2772)

### Description:
get_template_vm_list call needs to return templates at the entire DC level (in addition to specific cluster level) for infra VM WFs

### Resolution:
Extending get_template_vm_list call to return templates at the entire DC level

### Order of reviewing
n/a

### Testing:

**Unit Testing:**
Tested enhancements to existing APIs and new APIs using c3ntry_client 
