### PR TITLE
MRPHS-2773 MRPHS-3082 Graceful VM shutdown/restart and returning disk stats in get_vm_templates

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -699,6 +699,44 @@ var halt = func(vm *VM) error {
 	return nil
 }
 
+// shutDown Initiates guest shut down of this VM.
+var shutDown = func(vm *VM) error {
+	// Get a reference to the datacenter with host and vm folders populated
+	dcMo, err := GetDatacenter(vm)
+	if err != nil {
+		return err
+	}
+	vmMo, err := findVM(vm, dcMo, vm.Name)
+	if err != nil {
+		return err
+	}
+	vmo := object.NewVirtualMachine(vm.client.Client, vmMo.Reference())
+	err = vmo.ShutdownGuest(vm.ctx)
+	if err != nil {
+		return fmt.Errorf("error initiating shutDown on the vm: %s", err)
+	}
+	return nil
+}
+
+// restart Initiates guest reboot of this VM.
+var restart = func(vm *VM) error {
+	// Get a reference to the datacenter with host and vm folders populated
+	dcMo, err := GetDatacenter(vm)
+	if err != nil {
+		return err
+	}
+	vmMo, err := findVM(vm, dcMo, vm.Name)
+	if err != nil {
+		return err
+	}
+	vmo := object.NewVirtualMachine(vm.client.Client, vmMo.Reference())
+	err = vmo.RebootGuest(vm.ctx)
+	if err != nil {
+		return fmt.Errorf("error initiating reboot on the vm: %s", err)
+	}
+	return nil
+}
+
 var start = func(vm *VM) error {
 	// Get a reference to the datacenter with host and vm folders populated
 	dcMo, err := GetDatacenter(vm)

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -1475,14 +1475,16 @@ func GetTemplateList(vm *VM) ([]map[string]interface{}, error) {
 				devices := vmo.Config.Hardware.Device
 				diskInfo := make([]map[string]interface{}, 0)
 				for _, device := range devices {
-					if disk, ok := device.(*types.VirtualDisk); ok {
-						devinfo := disk.DeviceInfo
-						if di, ok := devinfo.(*types.Description); ok {
-							diskInfo = append(diskInfo, map[string]interface{}{
-								"name": di.Label,
-								"size": disk.CapacityInKB,
-							})
-						}
+					disk, ok := device.(*types.VirtualDisk)
+					if !ok {
+						continue
+					}
+					devinfo := disk.DeviceInfo
+					if di, ok := devinfo.(*types.Description); ok {
+						diskInfo = append(diskInfo, map[string]interface{}{
+							"name": di.Label,
+							"size": disk.CapacityInKB,
+						})
 					}
 				}
 				vmList = append(vmList, map[string]interface{}{


### PR DESCRIPTION
[MRPHS-2773](https://apporbit.atlassian.net/browse/MRPHS-2773)
[MRPHS-3082](https://apporbit.atlassian.net/browse/MRPHS-3082)

### Description:
1. Graceful shutdown and reboot is a requirement for infra VMs
2. get_template_vms needs to return disk info of templates to display on UI and help user make a choice during new VM creation

### Resolution:
Adding support for graceful shutdown and restart operations.
Returning name and size of disks for templates.

### Order of reviewing
n/a

### Testing:

**Component Testing:**
Tested enhancements to existing APIs and new APIs using c3ntry_client 
