### PR TITLE
MRPHS-3065 Fixing issues with custom network selection in create_vms

### DIFF
--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -493,8 +493,8 @@ type VM struct {
 	// If OvaPathUrl is given then OvaPathUrl will be used, if not then OvfPath will be used
 	// If Both are given preference will be given to OvaPathUrl.
 	OvaPathUrl string
-	// Networks defines a mapping from each network label inside the ovf file
-	// to a vSphere network. Must be available on the host or deploy will fail.
+	// Networks defines a slice of networks to be attached to the VM
+	// They must be available on the host or deploy will fail.
 	Networks []map[string]string
 	// Name is the name to use for the VM on vSphere and internally.
 	Name string

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -302,7 +302,7 @@ type ErrorParsingURL struct {
 type ErrorInvalidHost struct {
 	host string
 	ds   string
-	nw   map[string]string
+	nw   []map[string]string
 }
 
 func (e ErrorInvalidHost) Error() string {
@@ -365,7 +365,7 @@ func NewErrorParsingURL(u string, e error) ErrorParsingURL {
 }
 
 // NewErrorInvalidHost returns an ErrorInvalidHost error.
-func NewErrorInvalidHost(h string, d string, n map[string]string) ErrorInvalidHost {
+func NewErrorInvalidHost(h string, d string, n []map[string]string) ErrorInvalidHost {
 	return ErrorInvalidHost{host: h, ds: d, nw: n}
 }
 
@@ -495,7 +495,7 @@ type VM struct {
 	OvaPathUrl string
 	// Networks defines a mapping from each network label inside the ovf file
 	// to a vSphere network. Must be available on the host or deploy will fail.
-	Networks map[string]string
+	Networks []map[string]string
 	// Name is the name to use for the VM on vSphere and internally.
 	Name string
 	// Template is the name to use for the VM's template


### PR DESCRIPTION
[MRPHS-3065](https://apporbit.atlassian.net/browse/MRPHS-3065)

### Description:
When cloning from VM template to create new VM, we remove all network devices in the template and attach new ones of type 'e1000'. If the template has devices of different type, then they get new interface ids in the VM and are unable to connect to the network due to missing config files for the new identifiers.

### Resolution:
1. Changing default interface type to 'vmxnet3' for new interfaces (as per discussions)
2. Since user only has the capacity to select networks to be added to the new VM through AO but not interface type etc., editing existing devices in template with new network would retain their other properties including there types and identifiers. New approach to n/w configuration -
 a. If (number of networks mentioned by user) = (no. of devices in template), then edit template's devices in clone to be attached to n/ws entered by user.
 b. If (number of networks mentioned by user) > (no. of devices in template), then edit existing devices in order and add the pending as new ones
 c. If (number of networks mentioned by user) < (no. of devices in template), then edit existing devices in order and remove the excess ones.
3. `Network` property of VM object was a map. But, it is possible for a VM to have more than one device attached to the same n/w which won't be possible to represent in a map. Also, order of networks needs to be preserved. Changing type to `[]map[string]string` to preserve order and make it extendable for adding more properties per device

### Order of reviewing
n/a

### Testing:

**Unit Testing:**
Tested various combinations of n/w configs using c3ntry_client 
