### PR TITLE
MRPHS-3254: Assign static ip to vmware vm at the time of provisioning

### DIFF
--- a/virtualmachine/virtualmachine.go
+++ b/virtualmachine/virtualmachine.go
@@ -27,6 +27,12 @@ type VirtualMachine interface {
 	RemoveDisk([]string) error
 }
 
+type IpSetting struct {
+	Ip         string `json:"ip"`
+	Gateway    string `json:"gateway"`
+	SubnetMask string `json:"subnet_mask"`
+}
+
 const (
 	// VMStarting is the state to use when the VM is starting
 	VMStarting = "starting"

--- a/virtualmachine/virtualmachine.go
+++ b/virtualmachine/virtualmachine.go
@@ -27,7 +27,7 @@ type VirtualMachine interface {
 	RemoveDisk([]string) error
 }
 
-type IpSetting struct {
+type NetworkSettings struct {
 	Ip         string `json:"ip"`
 	Gateway    string `json:"gateway"`
 	SubnetMask string `json:"subnet_mask"`

--- a/virtualmachine/vsphere/constants.go
+++ b/virtualmachine/vsphere/constants.go
@@ -1,0 +1,64 @@
+package vsphere
+
+const STATICIP_CUSTOM_SPEC_NAME = "static-ip-libretto"
+const XML_STATIC_IP_SPEC = `
+<ConfigRoot>
+  <_type>vim.CustomizationSpecItem</_type>
+  <info>
+    <_type>vim.CustomizationSpecInfo</_type>
+    <changeVersion>1505235815</changeVersion>
+    <description/>
+    <lastUpdateTime>2017-09-12T17:03:35Z</lastUpdateTime>
+    <name>static-ip-libretto</name>
+    <type>Linux</type>
+  </info>
+  <spec>
+    <_type>vim.vm.customization.Specification</_type>
+    <globalIPSettings>
+      <_type>vim.vm.customization.GlobalIPSettings</_type>
+      <dnsServerList>
+        <_length>1</_length>
+        <_type>string[]</_type>
+        <e id="0">8.8.8.8</e>
+      </dnsServerList>
+      <dnsSuffixList>
+        <_length>1</_length>
+        <_type>string[]</_type>
+        <e id="0">google.com</e>
+      </dnsSuffixList>
+    </globalIPSettings>
+    <identity>
+      <_type>vim.vm.customization.LinuxPrep</_type>
+      <domain>gsintlab.com</domain>
+      <hostName>
+        <_type>vim.vm.customization.VirtualMachineNameGenerator</_type>
+      </hostName>
+      <hwClockUTC>true</hwClockUTC>
+      <timeZone>Indian/Antananarivo</timeZone>
+    </identity>
+    <nicSettingMap>
+      <_length>1</_length>
+      <_type>vim.vm.customization.AdapterMapping[]</_type>
+      <e id="0">
+        <_type>vim.vm.customization.AdapterMapping</_type>
+        <adapter>
+          <_type>vim.vm.customization.IPSettings</_type>
+          <gateway>
+            <_length>1</_length>
+            <_type>string[]</_type>
+            <e id="0">10.10.24.1</e>
+          </gateway>
+          <ip>
+            <_type>vim.vm.customization.FixedIp</_type>
+            <ipAddress>10.10.24.100</ipAddress>
+          </ip>
+          <subnetMask>255.255.255.0</subnetMask>
+        </adapter>
+      </e>
+    </nicSettingMap>
+    <options>
+      <_type>vim.vm.customization.LinuxOptions</_type>
+    </options>
+  </spec>
+</ConfigRoot>
+`

--- a/virtualmachine/vsphere/constants.go
+++ b/virtualmachine/vsphere/constants.go
@@ -24,7 +24,7 @@ const XML_STATIC_IP_SPEC = `
       <dnsSuffixList>
         <_length>1</_length>
         <_type>string[]</_type>
-        <e id="0">google.com</e>
+        <e id="0">gsintlab.com</e>
       </dnsSuffixList>
     </globalIPSettings>
     <identity>
@@ -33,8 +33,6 @@ const XML_STATIC_IP_SPEC = `
       <hostName>
         <_type>vim.vm.customization.VirtualMachineNameGenerator</_type>
       </hostName>
-      <hwClockUTC>true</hwClockUTC>
-      <timeZone>Indian/Antananarivo</timeZone>
     </identity>
     <nicSettingMap>
       <_length>1</_length>

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -520,15 +520,15 @@ type VM struct {
 	// linked clones.
 	UseLinkedClones bool
 	// Skip waiting for IP to be assigned to VM in create/start actions
-	SkipIPWait bool
-	uri        *url.URL
-	ctx        context.Context
-	cancel     context.CancelFunc
-	client     *govmomi.Client
-	finder     finder
-	collector  collector
-	datastore  string
-	IpSetting  lvm.IpSetting
+	SkipIPWait      bool
+	uri             *url.URL
+	ctx             context.Context
+	cancel          context.CancelFunc
+	client          *govmomi.Client
+	finder          finder
+	collector       collector
+	datastore       string
+	NetworkSettings lvm.NetworkSettings
 }
 
 // Provision provisions this VM.

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -521,13 +521,14 @@ type VM struct {
 	UseLinkedClones bool
 	// Skip waiting for IP to be assigned to VM in create/start actions
 	SkipIPWait bool
-	uri             *url.URL
-	ctx             context.Context
-	cancel          context.CancelFunc
-	client          *govmomi.Client
-	finder          finder
-	collector       collector
-	datastore       string
+	uri        *url.URL
+	ctx        context.Context
+	cancel     context.CancelFunc
+	client     *govmomi.Client
+	finder     finder
+	collector  collector
+	datastore  string
+	IpSetting  lvm.IpSetting
 }
 
 // Provision provisions this VM.


### PR DESCRIPTION
**Jira-Ticket**

**Problem**

Assign static ip to vmware vm at the time of provisioning. 

**Solution**

Created a custom spec in vcenter db with name 'static-ip-libretto' if it doesn't exist.
Get the static ip and updated the spec and passed it to the vm during clone.

**Unit testing**

Tried creating vm with the below inputs:
1) static ip and custom spec does not exist in vcenter db
SUCCESS- VM is created successfully with the static ip and custom spec is created in vcenter db.
2) static ip and custom spec exists in vcenter db
SUCCESS- VM is created successfully with the static ip.
3) static ip is not sent
SUCCESS- VM is created successfully with the ip assigned via dhcp.

Logs below:

**No static-ip**
```
input :- {"Host":"dev-vcenter.gsintlab.com","Destination":{"DestinationName":"C3 Cluster-1","DestinationType":"cluster","HostSystem":"67.220.186.4"},"Username":"","Password":"","Insecure":true,"Datacenter":"C3 DataCenter","OvaPathUrl":"apporbit-visor-2.1.ova","Networks":[{"name":"VM Private"}],"Name":"avni_2","Size":"small","Datastores":["datastore2-ESXi13-2TB"],"Template":"visor_template_2.1","SkipExisting":2}


[root@my_machine test]# go run vsphereclient.go
Ip List : {"IPs":["10.10.24.120"],"Id":"vm-5019"}
[root@my_machine test]#
```

**with static-ip**

```
input:- {"ipsetting":{"ip":"10.10.24.239","subnet_mask":"255.255.255.0","gateway":""},"Host":"dev-vcenter.gsintlab.com","Destination":{"DestinationName":"C3 Cluster-1","DestinationType":"cluster","HostSystem":"67.220.186.4"},"Username":"","Password":"","Insecure":true,"Datacenter":"C3 DataCenter","OvaPathUrl":"apporbit-visor-2.1.ova","Networks":[{"name":"VM Private"}],"Name":"avni_2","Size":"small","Datastores":["datastore2-ESXi13-2TB"],"Template":"visor_template_2.1","SkipExisting":2}


[root@my_machine test]# go run vsphereclient.go
Ip List : {"IPs":["10.10.24.239"],"Id":"vm-5024"}
[root@my_machine test]#
```
