### PR TITLE
MRPHS-3169 : Support in halo to clone a VM template using the config associated with the template provided

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -482,8 +482,8 @@ func reconfigureNetworks(vm *VM, vmObj *object.VirtualMachine) ([]types.BaseVirt
 			nw = vm.Networks[idx]
 			for _, nwMappingObj := range networkMapping {
 				if nwMappingObj.Name == nw["name"] {
-					device.GetVirtualDevice().Backing = &types.VirtualEthernetCardNetworkBackingInfo {
-						VirtualDeviceDeviceBackingInfo: types.VirtualDeviceDeviceBackingInfo {
+					device.GetVirtualDevice().Backing = &types.VirtualEthernetCardNetworkBackingInfo{
+						VirtualDeviceDeviceBackingInfo: types.VirtualDeviceDeviceBackingInfo{
 							DeviceName: nwMappingObj.Name,
 						},
 						Network: &nwMappingObj.Network,
@@ -576,6 +576,14 @@ var cloneFromTemplate = func(vm *VM, dcMo *mo.Datacenter, usableDatastores []str
 	}
 	hotAddMemory := true
 	hotAddCpu := true
+
+	if vm.Flavor.NumCPUs <= 0 {
+		vm.Flavor.NumCPUs = vmMo.Config.Hardware.NumCPU
+	}
+
+	if vm.Flavor.MemoryMB <= 0 {
+		vm.Flavor.MemoryMB = int64(vmMo.Config.Hardware.MemoryMB)
+	}
 
 	config := types.VirtualMachineConfigSpec{
 		NumCPUs:             vm.Flavor.NumCPUs,


### PR DESCRIPTION
### Symptom:
https://apporbit.atlassian.net/browse/MRPHS-3169

### Description:
If no explicit value of CPU and memory are specified,  then unable to deploy machine.
we have to override with vm template config values.


### Resolution:
If no explicit value of CPU and memory are specified, use the default values associated with the VM template.

### Testing:

**Unit Testing:**
```
[root@deepali-dev3 vmware-cli]# go run vsphereclient.go
Vm created and is powered on
{"IPs":["10.10.24.54"],"Id":"vm-5055"}

createVm.json : 
{"Host":"209.205.216.11","Destination":{"DestinationName":"C3 Cluster-1","DestinationType":"cluster","HostSystem":"67.220.186.4"},"Username":"c3@vsphere.local","Password":"D0great12)_c3"                    ,"Insecure":true,"Datacenter":"C3 DataCenter","OvaPathUrl":"apporbit-visor-2.1.ova","Networks":{"name":"VM Private"},"Name":"deepali_vme","Datastores":["datastore2-ESXi13-2TB"],"Template ":"visor_template_2.1","SkipExisting":2, "Size": "custom", "Config": { "Vcpus": 0 }}

