### PR TITLE
MRPHS-3169 : Added code for getting vm tool status in vm info api

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -399,7 +399,7 @@ func searchTree(vm *VM, mor types.ManagedObjectReference, name string) (*mo.Virt
 	case "VirtualMachine":
 		// Base recursive case, compare for value
 		vmMo := mo.VirtualMachine{}
-		err := vm.collector.RetrieveOne(vm.ctx, mor, []string{"name", "config", "guest.ipAddress", "guest.guestState", "guest.net", "runtime.question", "snapshot.currentSnapshot"}, &vmMo)
+		err := vm.collector.RetrieveOne(vm.ctx, mor, []string{"name", "config", "guest.ipAddress", "guest.guestState", "guest.net", "runtime.question", "snapshot.currentSnapshot", "guest.toolsRunningStatus"}, &vmMo)
 		if err != nil {
 			return nil, NewErrorObjectNotFound(errors.New("could not find the vm"), name)
 		}
@@ -1158,7 +1158,6 @@ func getState(vm *VM) (state string, err error) {
 	if err != nil {
 		return "", lvm.ErrVMInfoFailed
 	}
-
 	return vmMo.Guest.GuestState, nil
 }
 


### PR DESCRIPTION
### Symptom:

[\<JiraID>](https://apporbit.atlassian.net/browse/Mrphs 2779)

### Description:
Need to send CPU, memory, disk usage, VM tools installed, network information, etc.

### Resolution:
Added code for sending this info
### Testing:

**Unit Testing:**
```
root@deepali-dev3 vmware-cli]# go run vsphereclient.go

{"VMId":"vm-5121","IpAddress":["67.220.186.54"],"ToolsRunningStatus":"guestToolsRunning"}