### PR TITLE
Mrphs 2779- <liberatto>: Discover extended VM configuration state

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -399,7 +399,7 @@ func searchTree(vm *VM, mor types.ManagedObjectReference, name string) (*mo.Virt
 	case "VirtualMachine":
 		// Base recursive case, compare for value
 		vmMo := mo.VirtualMachine{}
-		err := vm.collector.RetrieveOne(vm.ctx, mor, []string{"name", "config", "guest.ipAddress", "guest.guestState", "guest.net", "runtime.question", "snapshot.currentSnapshot"}, &vmMo)
+		err := vm.collector.RetrieveOne(vm.ctx, mor, []string{"name", "config", "guest.ipAddress", "guest.guestState", "guest.net", "runtime.question", "snapshot.currentSnapshot", "guest.toolsRunningStatus", "summary.quickStats"}, &vmMo)
 		if err != nil {
 			return nil, NewErrorObjectNotFound(errors.New("could not find the vm"), name)
 		}

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -462,6 +462,14 @@ type Lease interface {
 	Complete() error
 }
 
+type VMInfo struct {
+	VMId               string
+	IpAddress          []net.IP
+	ToolsRunningStatus string
+	OverallCpuUsage    int64
+	GuestMemoryUsage   int64
+}
+
 type Flavor struct {
 	// Represents the number of CPUs
 	NumCPUs int32
@@ -836,6 +844,36 @@ func (vm *VM) Destroy() (err error) {
 		return fmt.Errorf("destroy task returned an error: %s", err)
 	}
 	return nil
+}
+
+//GetVMInfo returns information of this VM.
+func (vm *VM) GetVMInfo() (VMInfo, error) {
+	var vmInfo VMInfo
+	if err := SetupSession(vm); err != nil {
+		return vmInfo, err
+	}
+	defer vm.cancel()
+
+	// Get a reference to the datacenter with host and vm folders populated
+	dcMo, err := GetDatacenter(vm)
+	if err != nil {
+		return vmInfo, err
+	}
+	vmMo, err := findVM(vm, dcMo, vm.Name)
+	if err != nil {
+		return vmInfo, err
+	}
+
+	ips, vmid, err := vm.GetIPsAndId()
+	toolsRunningStatus := vmMo.Guest.ToolsRunningStatus
+
+	vmInfo.VMId = vmid
+	vmInfo.IpAddress = ips
+	vmInfo.ToolsRunningStatus = toolsRunningStatus
+	vmInfo.OverallCpuUsage = int64(vmMo.Summary.QuickStats.OverallCpuUsage)
+	vmInfo.GuestMemoryUsage = int64(vmMo.Summary.QuickStats.GuestMemoryUsage)
+
+	return vmInfo, nil
 }
 
 // GetState returns the power state of this VM.


### PR DESCRIPTION
### Symptom:
[\<JiraID>](https://apporbit.atlassian.net/browse/Mrphs 2779)

 

### Description:
Need to send CPU, memory, disk usage, VM tools installed, network information, etc.

### Resolution:
Added code for sending this info
### Testing:

**Unit Testing:**
```
[root@deepali-dev3 vmware-cli2]# go run vsphereclient.go
{"VMId":"vm-637","IpAddress":["10.10.24.78","fe80::250:56ff:fe89:4598","fe80::d864:38ff:fe65:3abc","67.220.185.221","fe80::250:56ff:fe89:6833","172.17.0.1","fe80::42:edff:fe60:56bc"],"ToolsRunningStatus":"guestToolsRunning","OverallCpuUsage":35,"GuestMemoryUsage":81}