### PR TITLE
MRPHS-3427: Create disk on different datstore in add volume operation

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -719,8 +719,9 @@ func CreateDisk(l object.VirtualDeviceList, c types.BaseVirtualController, ds ty
 	return device
 }
 
-//reconfigureVM :reconfigureVM adds the disks to the vm and returns the vmdk
+// reconfigureVM :reconfigureVM adds the disks to the vm and returns the vmdk
 // file names of the disks added
+// root disk datastore is used by default
 var reconfigureVM = func(vm *VM, vmMo *mo.VirtualMachine) ([]string, error) {
 	var (
 		vDisk           *types.VirtualDisk
@@ -740,6 +741,7 @@ var reconfigureVM = func(vm *VM, vmMo *mo.VirtualMachine) ([]string, error) {
 	}
 
 	for _, disk := range vm.Disks {
+		// root disk datastore is used by default
 		if disk.Datastore == "" {
 			datastore = vm.datastore
 		} else {

--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -725,6 +725,7 @@ var reconfigureVM = func(vm *VM, vmMo *mo.VirtualMachine) ([]string, error) {
 	var (
 		vDisk           *types.VirtualDisk
 		thinProvisioned bool
+		datastore       string
 	)
 	vmObj := object.NewVirtualMachine(vm.client.Client, vmMo.Reference())
 
@@ -738,17 +739,21 @@ var reconfigureVM = func(vm *VM, vmMo *mo.VirtualMachine) ([]string, error) {
 		return nil, err
 	}
 
-	dsMo, err := findDatastore(vm, dcMo, vm.datastore)
-	if err != nil {
-		return nil, err
-	}
-
 	for _, disk := range vm.Disks {
+		if disk.Datastore == "" {
+			datastore = vm.datastore
+		} else {
+			datastore = disk.Datastore
+		}
 		devices, err := vmObj.Device(vm.ctx)
 		if err != nil {
 			return nil, err
 		}
 		controller, err := devices.FindDiskController(disk.Controller)
+		if err != nil {
+			return nil, err
+		}
+		dsMo, err := findDatastore(vm, dcMo, datastore)
 		if err != nil {
 			return nil, err
 		}

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -408,6 +408,7 @@ type Disk struct {
 	Size         int64
 	Controller   string
 	Provisioning string
+	Datastore    string
 }
 
 // Snapshot represents a vSphere snapshot to create


### PR DESCRIPTION
**Jira id**

MRPHS-3427

**Problem**

Provision to create volume from different datastores.

**Solution**

Passed the datastore along with the disk properties and created a new volume using that datastore.

**Unit Testing**

In progress.