### PR TITLE
MRPHS-3431: Assign networksettings in create_vms call, added dns_server to the settings

### DIFF
--- a/virtualmachine/virtualmachine.go
+++ b/virtualmachine/virtualmachine.go
@@ -28,9 +28,10 @@ type VirtualMachine interface {
 }
 
 type NetworkSettings struct {
-	Ip         string `json:"ip"`
-	Gateway    string `json:"gateway"`
+	Ip         string `json:"ip_address"`
+	Gateway    string `json:"default_gateway"`
 	SubnetMask string `json:"subnet_mask"`
+	DnsServer  string `json:"dns_server"`
 }
 
 const (

--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -1285,6 +1285,7 @@ func updateCustomSpec(vm *VM,
 	if vm.NetworkSettings.Ip == "" || vm.NetworkSettings.SubnetMask == "" {
 		return nil
 	}
+	// set ip address, subnet mask, default gateway
 	nicSetting := customSpec.NicSettingMap[0]
 	ip := nicSetting.Adapter.Ip
 	ipValue := reflect.ValueOf(ip).Elem()
@@ -1295,6 +1296,12 @@ func updateCustomSpec(vm *VM,
 	nicSetting.Adapter.SubnetMask = vm.NetworkSettings.SubnetMask
 	gateway := vm.NetworkSettings.Gateway
 	nicSetting.Adapter.Gateway = append(nicSetting.Adapter.Gateway, gateway)
+
+	// set dns server
+	if vm.NetworkSettings.DnsServer != "" {
+		customSpec.GlobalIPSettings.DnsServerList = []string{
+			vm.NetworkSettings.DnsServer}
+	}
 
 	return customSpec
 }

--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -615,7 +615,7 @@ var cloneFromTemplate = func(vm *VM, dcMo *mo.Datacenter, usableDatastores []str
 	if err != nil {
 		return fmt.Errorf("Error retrieving custom spec: %v", err)
 	}
-	customSpec := updateCustomSpec(vm, &customSpecItem.Spec)
+	customSpec := updateCustomSpec(vm, vmMo, &customSpecItem.Spec)
 
 	cisp := types.VirtualMachineCloneSpec{
 		Location:      relocateSpec,
@@ -1279,7 +1279,7 @@ func createCustomSpecStaticIp(vm *VM) error {
 }
 
 // updateCustomSpec: updates custom spec structure with the ip settings
-func updateCustomSpec(vm *VM,
+func updateCustomSpec(vm *VM, tempMo *mo.VirtualMachine,
 	customSpec *types.CustomizationSpec) *types.CustomizationSpec {
 	// if ip or subnet is not passed return nil
 	if vm.NetworkSettings.Ip == "" || vm.NetworkSettings.SubnetMask == "" {
@@ -1299,8 +1299,14 @@ func updateCustomSpec(vm *VM,
 
 	// set dns server
 	if vm.NetworkSettings.DnsServer != "" {
-		customSpec.GlobalIPSettings.DnsServerList = []string{
-			vm.NetworkSettings.DnsServer}
+		dnsServerList := []string{vm.NetworkSettings.DnsServer}
+		for _, ip := range tempMo.Guest.IpStack {
+			dnsServerList = append(dnsServerList,
+				ip.DnsConfig.IpAddress...)
+		}
+		customSpec.GlobalIPSettings.DnsServerList = append(
+			customSpec.GlobalIPSettings.DnsServerList,
+			dnsServerList...)
 	}
 
 	return customSpec


### PR DESCRIPTION
**Jira id**

MRPHS-3431

**Problem**

In static ip settings, support to set the dns server is not there.

**Solution**

Added support for adding dns server to the vm created.

**Unit testing**

Done. Tried creating vm with static ip and dns_server.

The vm is created successfully with the requested ip and dns server. Input network settings:
{"networksettings":{"ip_address":"10.10.24.239","subnet_mask":"255.255.255.0","default_gateway":"","dns_server":"8.8.4.4"}}

<img width="639" alt="screen shot 2017-10-06 at 1 34 45 pm" src="https://user-images.githubusercontent.com/22026464/31268708-2d791bd2-aa9b-11e7-805c-a519bb4238fa.png">
