### PR TITLE
MRPHS-3435: Added support for changing the disk provisioning of disk

### DIFF
--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -405,8 +405,9 @@ type collector interface {
 
 // Disk represents a vSphere Disk to attach to the VM
 type Disk struct {
-	Size       int64
-	Controller string
+	Size         int64
+	Controller   string
+	Provisioning string
 }
 
 // Snapshot represents a vSphere snapshot to create


### PR DESCRIPTION
**Jira-ID**

MRPHS-3435

**Problem**

[VMWARE] Support for providing the disk provisioning in the add disk call is not there

**Solution**

Added support for providing disk provisioning in the add disk operation. By default the provisioning is 'thin' type.

**Unit testing**

Done. Tried adding disk with provisioning type thick and thin. The disk of type provisioning as given in the input is added to the vm. Screenshot below:

<img width="898" alt="screen shot 2017-10-09 at 3 49 06 pm" src="https://user-images.githubusercontent.com/22026464/31334017-f732a482-ad09-11e7-8bdf-0c3ef9e7b27a.png">





