### PR TITLE
MRPHS-3461: Extend GCP support

### DIFF
--- a/virtualmachine/gcp/util.go
+++ b/virtualmachine/gcp/util.go
@@ -601,7 +601,7 @@ func (svc *googleService) getFirewall() (*googlecloud.Firewall, error) {
 	return svc.service.Firewalls.Get(svc.vm.Project, svc.vm.Firewall).Do()
 }
 
-// addFirewallPorts adds new ports to a firewall
+// addFirewallRules adds new ports to a firewall
 func (svc *googleService) addFirewallRules() error {
 
 	currFirewall, err := svc.getFirewall()
@@ -632,7 +632,7 @@ func (svc *googleService) patchFirewall(allowed []*googlecloud.FirewallAllowed) 
 	return svc.waitForGlobalOperationReady(op.Name)
 }
 
-// removeFirewallPorts removes ports from a given firewall
+// removeFirewallRules removes ports from a given firewall
 func (svc *googleService) removeFirewallRules() error {
 	// Define a map to identify ports to be removed. It will record the
 	// ports with corresponding protocol as remPorts[Protocol][Port] = true

--- a/virtualmachine/gcp/util.go
+++ b/virtualmachine/gcp/util.go
@@ -717,3 +717,9 @@ func (svc *googleService) getImageList() ([]*googlecloud.Image, error) {
 
 	return imageListAll, nil
 }
+
+// convResURLToName returns resource name from the given resource URL
+func convResURLToName(url string) string {
+	urlSplit := strings.Split(url, "/")
+	return urlSplit[len(urlSplit)-1]
+}

--- a/virtualmachine/gcp/vm.go
+++ b/virtualmachine/gcp/vm.go
@@ -10,6 +10,7 @@ import (
 	"github.com/apcera/libretto/ssh"
 	"github.com/apcera/libretto/util"
 	"github.com/apcera/libretto/virtualmachine"
+	"strings"
 )
 
 const (
@@ -21,6 +22,14 @@ const (
 
 	// OperationTimeout represents Maximum time(Second) to wait for operation ready.
 	OperationTimeout = 180
+
+	// DevicePathPrefix represents the prefix of the path given to the
+	// disks attached to an instance. If a disk named "disk1" is attached
+	// to an instance, it's path on the GCE instance becomes
+	// "/dev/disk/by-id/google-disk1". This name can be used to reference
+	// the device for mounting, resizing, and so on, from within the
+	// instance.
+	DevicePathPrefix = "/dev/disk/by-id/google-"
 )
 
 // SSHTimeout is the maximum time to wait before failing to GetSSH. This is not
@@ -36,6 +45,7 @@ var (
 type VM struct {
 	Name        string
 	Description string
+	Region      string
 	Zone        string
 	MachineType string
 	Preemptible bool // Preemptible instances will be terminates after they run for 24 hours.
@@ -56,17 +66,127 @@ type VM struct {
 
 	AccountFile  string
 	account      accountFile
-	SSHCreds     ssh.Credentials // privateKey is required for GCE
+	SSHCreds     ssh.Credentials
 	SSHPublicKey string
+
+	Firewall  string // required when modifying firewall rules
+	Endpoints []Endpoint
+}
+
+// Endpoint represents the protocol and ports configured in a firewall
+type Endpoint struct {
+	// Protocol can be one of the following well known protocol strings
+	// (tcp, udp, icmp, esp, ah, sctp) which are supported by GCP
+	Protocol string
+	Ports    []string
+}
+
+// Image represents a GCE image
+type Image struct {
+	Id                uint64 `json:"id,omitempty,string"`
+	CreationTimestamp string `json:"creation_timestamp,omitempty"`
+	// DeprecationStatus indicates whether the image is depcrecated. If the
+	// image is not deprecated it will have an empty string.
+	DeprecationStatus string `json:"deprecation_status,omitempty"`
+	// DeprecationReplacement provides the url of the image which is a
+	// replacement of this deprecated image. If this image is not deprecated
+	// it's value will be an empty string.
+	DeprecationReplacement string `json:"deprecation_replacement,omitempty"`
+	Description            string `json:"description,omitempty"`
+	DiskSizeGb             int64  `json:"disk_size_gb,omitempty,string"`
+	Family                 string `json:"family,omitempty"`
+	Name                   string `json:"name,omitempty"`
+	Status                 string `json:"status,omitempty"`
 }
 
 // Disk represents the GCP Disk.
 // See https://cloud.google.com/compute/docs/disks/?hl=en_US&_ga=1.115106433.702756738.1463769954
 type Disk struct {
-	Name       string
-	DiskType   string
-	DiskSizeGb int
-	AutoDelete bool // Auto delete disk
+	Name        string
+	DiskType    string
+	DiskSizeGb  int
+	AutoDelete  bool // Auto delete disk
+	Description string
+}
+
+// AttachedDisk represents a disk attached to a GCE instance
+type AttachedDisk struct {
+	Name       string `json:"name,omitempty"`
+	DevicePath string `json:"device_path,omitempty"`
+	Boot       *bool  `json:"boot,omitempty"`
+	AutoDelete *bool  `json:"auto_delete,omitempty"`
+	Interface  string `json:"interface,omitempty"`
+}
+
+// Network defines a VPC network in GCP
+type Network struct {
+	Name                  string   `json:"name,omitempty"`
+	Description           string   `json:"description,omitempty"`
+	Id                    uint64   `json:"id,omitempty,string"`
+	AutoCreateSubnetworks *bool    `json:"auto_create_subnetworks,omitempty"`
+	IPv4Range             string   `json:"ipv4_range,omitempty"`
+	CreationTimestamp     string   `json:"creation_timestamp,omitempty"`
+	Subnetworks           []string `json:"subnetworks,omitempty"`
+}
+
+// Subnetwork represents a GCP subnetwork in a region
+type Subnetwork struct {
+	Name              string `json:"name,omitempty"`
+	Description       string `json:"description,omitempty"`
+	Id                uint64 `json:"id,omitempty,string"`
+	CreationTimestamp string `json:"creation_timestamp,omitempty"`
+	GatewayAddress    string `json:"gateway_address,omitempty"`
+	Network           string `json:"network,omitempty"`
+	Region            string `json:"region,omitempty"`
+	IpCidrRange       string `json:"ipv4_range,omitempty"`
+}
+
+// MachinType defines GCP machine type (aka flavors)
+type MachineType struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	GuestCpus   int64  `json:"cpus,omitempty"`
+	MemoryMb    int64  `json:"memory_mb,omitempty"`
+	IsSharedCpu *bool  `json:"is_shared_cpu,omitempty"`
+	// Maximum persistent disks allowed
+	MaximumPersistentDisks int64 `json:"max_persistent_disks,omitempty"`
+	// Maximum total persistent disks size (GB) allowed
+	MaximumPersistentDisksSizeGb int64 `json:"max_persistent_disks_size_gb,omitempty,string"`
+}
+
+// DiskType defines GCP disk type
+type DiskType struct {
+	Name              string `json:"name,omitempty"`
+	Description       string `json:"description,omitempty"`
+	ValidDiskSize     string `json:"valid_size,omitempty"`
+	DefaultDiskSizeGb int64  `json:"default_disk_size_gb,omitempty,string"`
+}
+
+// Zone represents a GCP zone
+type Zone struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	Region      string `json:"region,omitempty"`
+	Status      string `json:"status,omitempty"`
+}
+
+// Region represents a GCP region
+type Region struct {
+	Name        string   `json:"name,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Zones       []string `json:"zones,omitempty"`
+	Status      string   `json:"status,omitempty"`
+}
+
+// InstanceData represents the details of a launched GCE instance
+type InstanceData struct {
+	Name              string         `json:"name,omitempty"`
+	Id                uint64         `json:"id,omitempty,string"`
+	Status            string         `json:"status,omitempty"`
+	CreationTimestamp string         `json:"creation_timestamp,omitempty"`
+	PrivateIpv4       string         `json:"private_ipv4,omitempty"`
+	PublicIpv4        string         `json:"public_ipv4,omitempty"`
+	Volumes           []AttachedDisk `json:"volumes,omitempty"`
 }
 
 // GetName returns the name of the virtual machine.
@@ -159,6 +279,16 @@ func (vm *VM) Start() error {
 	return s.start()
 }
 
+// Reset a GCE instance.
+func (vm *VM) Reset() error {
+	s, err := vm.getService()
+	if err != nil {
+		return err
+	}
+
+	return s.reset()
+}
+
 // GetSSH returns an SSH client connected to the instance.
 func (vm *VM) GetSSH(options ssh.Options) (ssh.Client, error) {
 	ips, err := vm.GetIPs()
@@ -206,10 +336,372 @@ func (vm *VM) DeleteDisks() error {
 	return nil
 }
 
-func (vm *VM) AddDisk() error {
-        return errors.New("TO-DO")
+// This function cannot be used in GCP as defined in the interface. The
+// function's signature will be different for vsphere, gcp and aws. This can be
+// cleaned up when the VirtualMachine interface is corrected. Please refer to
+// AddNewDisks function to add new disks to an instance.
+func (vm *VM) AddDisk() ([]string, error) {
+	return nil, nil
 }
 
-func (vm *VM) RemoveDisk(diskName string) error {
-        return errors.New("TO-DO")
+// This function cannot be used in GCP as defined in the interface. The
+// function's signature will be different for vsphere, gcp and aws. This can be
+// cleaned up when the VirtualMachine interface is corrected. Please refer to
+// DeleteVMDisks function to detach and delete disks from a VM.
+func (vm *VM) RemoveDisk(diskName []string) error {
+	return errors.New("TO-DO")
+}
+
+// GetNetworkList gets the list of VPC networks
+func (vm *VM) GetNetworkList() ([]Network, error) {
+	var response []Network
+	s, err := vm.getService()
+	if err != nil {
+		return nil, err
+	}
+
+	networkList, err := s.getNetworkList()
+	if err != nil {
+		return nil, err
+	}
+
+	subnetworks := make([]string, 0)
+	for _, network := range networkList {
+		subnetworks = nil
+		for _, subnetworkURL := range network.Subnetworks {
+			subnetworks = append(subnetworks,
+				convResURLToName(subnetworkURL))
+		}
+		response = append(response, Network{
+			Name:                  network.Name,
+			Description:           network.Description,
+			Id:                    network.Id,
+			AutoCreateSubnetworks: &network.AutoCreateSubnetworks,
+			CreationTimestamp:     network.CreationTimestamp,
+			IPv4Range:             network.IPv4Range,
+			Subnetworks:           subnetworks})
+	}
+
+	return response, nil
+}
+
+// GetSubnetworkList gets the list of subnetworks
+func (vm *VM) GetSubnetworkList() ([]Subnetwork, error) {
+	s, err := vm.getService()
+	if err != nil {
+		return nil, err
+	}
+
+	subnetworkList, err := s.getSubnetworkList()
+	if err != nil {
+		return nil, err
+	}
+
+	response := make([]Subnetwork, 0)
+
+	for _, subnetwork := range subnetworkList {
+		networkName := convResURLToName(subnetwork.Network)
+		regionName := convResURLToName(subnetwork.Region)
+		response = append(response, Subnetwork{
+			Name:              subnetwork.Name,
+			Description:       subnetwork.Description,
+			Id:                subnetwork.Id,
+			CreationTimestamp: subnetwork.CreationTimestamp,
+			Network:           networkName,
+			Region:            regionName,
+			GatewayAddress:    subnetwork.GatewayAddress,
+			IpCidrRange:       subnetwork.IpCidrRange,
+		})
+	}
+
+	return response, nil
+}
+
+// GetMachineTypeList gets the list of available machine types (aka flavors)
+func (vm *VM) GetMachineTypeList() ([]MachineType, error) {
+	s, err := vm.getService()
+	if err != nil {
+		return nil, err
+	}
+
+	machineTypeList, err := s.getMachineTypeList()
+	if err != nil {
+		return nil, err
+	}
+
+	response := make([]MachineType, 0)
+
+	for _, machineType := range machineTypeList {
+		response = append(response, MachineType{
+			Name:                         machineType.Name,
+			Description:                  machineType.Description,
+			GuestCpus:                    machineType.GuestCpus,
+			MemoryMb:                     machineType.MemoryMb,
+			IsSharedCpu:                  &machineType.IsSharedCpu,
+			MaximumPersistentDisks:       machineType.MaximumPersistentDisks,
+			MaximumPersistentDisksSizeGb: machineType.MaximumPersistentDisksSizeGb,
+		})
+	}
+
+	return response, nil
+}
+
+// GetDiskTypeList gets the list of available disk types
+func (vm *VM) GetDiskTypeList() ([]DiskType, error) {
+	s, err := vm.getService()
+	if err != nil {
+		return nil, err
+	}
+
+	diskTypeList, err := s.getDiskTypeList()
+	if err != nil {
+		return nil, err
+	}
+
+	response := make([]DiskType, 0)
+
+	for _, diskType := range diskTypeList {
+		response = append(response, DiskType{
+			Name:              diskType.Name,
+			Description:       diskType.Description,
+			ValidDiskSize:     diskType.ValidDiskSize,
+			DefaultDiskSizeGb: diskType.DefaultDiskSizeGb,
+		})
+	}
+
+	return response, nil
+}
+
+// GetZoneList gets the list of available zones
+func (vm *VM) GetZoneList() ([]Zone, error) {
+	s, err := vm.getService()
+	if err != nil {
+		return nil, err
+	}
+
+	zoneList, err := s.getZoneList()
+	if err != nil {
+		return nil, err
+	}
+
+	response := make([]Zone, 0)
+
+	for _, zone := range zoneList {
+		regionName := convResURLToName(zone.Region)
+		response = append(response, Zone{
+			Name:        zone.Name,
+			Description: zone.Description,
+			Region:      regionName,
+			Status:      zone.Status,
+		})
+	}
+
+	return response, nil
+}
+
+// GetRegionList gets the list of available regions
+func (vm *VM) GetRegionList() ([]Region, error) {
+	s, err := vm.getService()
+	if err != nil {
+		return nil, err
+	}
+
+	regionList, err := s.getRegionList()
+	if err != nil {
+		return nil, err
+	}
+
+	response := make([]Region, 0)
+
+	zones := make([]string, 0)
+	for _, region := range regionList {
+		zones = nil
+		for _, zoneUrl := range region.Zones {
+			zones = append(zones, convResURLToName(zoneUrl))
+		}
+		response = append(response, Region{
+			Name:        region.Name,
+			Description: region.Description,
+			Zones:       zones,
+			Status:      region.Status,
+		})
+	}
+
+	return response, nil
+}
+
+// convResURLToName returns resource name from the given resource URL
+func convResURLToName(url string) string {
+	urlSplit := strings.Split(url, "/")
+	return urlSplit[len(urlSplit)-1]
+}
+
+// AddNewDisks adds a new disks to an instance
+func (vm *VM) AddNewDisks() ([]AttachedDisk, error) {
+	disksPresent := make(map[string]bool)
+	response := make([]AttachedDisk, 0)
+
+	s, err := vm.getService()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, disk := range vm.Disks {
+		if err := s.createDisk(&disk); err != nil {
+			return nil, err
+		}
+
+		if err := s.attachDisk(&disk); err != nil {
+			return nil, err
+		}
+		disksPresent[disk.Name] = true
+	}
+
+	instance, err := s.getInstance()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, attachedDisk := range instance.Disks {
+		if disksPresent[attachedDisk.DeviceName] {
+			response = append(response, AttachedDisk{
+				Name:       attachedDisk.DeviceName,
+				Boot:       &attachedDisk.Boot,
+				AutoDelete: &attachedDisk.AutoDelete,
+				Interface:  attachedDisk.Interface,
+				DevicePath: DevicePathPrefix +
+					attachedDisk.DeviceName,
+			})
+		}
+	}
+	return response, nil
+}
+
+// IsInstance checks if the given instance is present in GCP. Returns true if
+// instance is available else false.
+func (vm *VM) IsInstance() (bool, error) {
+	s, err := vm.getService()
+	if err != nil {
+		return false, err
+	}
+
+	_, err = s.getInstance()
+	if err != nil {
+		return false, err
+	} else {
+		return true, nil
+	}
+}
+
+// DeleteVMDisk detaches the given disks from the instance and deletes them
+func (vm *VM) DeleteVMDisks() error {
+	s, err := vm.getService()
+	if err != nil {
+		return err
+	}
+
+	for _, disk := range vm.Disks {
+		if err := s.detachDisk(&disk); err != nil {
+			return err
+		}
+
+		if err := s.deleteDisk(disk.Name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetInstance gets instance details
+func (vm *VM) GetInstance() (*InstanceData, error) {
+	s, err := vm.getService()
+	if err != nil {
+		return nil, err
+	}
+
+	instance, err := s.getInstance()
+	if err != nil {
+		return nil, err
+	}
+	ips, err := vm.GetIPs()
+	if err != nil {
+		return nil, err
+	}
+
+	vmResponse := &InstanceData{
+		Name:              instance.Name,
+		Id:                instance.Id,
+		CreationTimestamp: instance.CreationTimestamp,
+		Status:            instance.Status,
+		PrivateIpv4:       ips[PrivateIP].String(),
+		PublicIpv4:        ips[PublicIP].String(),
+	}
+	for _, attachedDisk := range instance.Disks {
+		vmResponse.Volumes = append(vmResponse.Volumes, AttachedDisk{
+			Name:       attachedDisk.DeviceName,
+			Boot:       &attachedDisk.Boot,
+			AutoDelete: &attachedDisk.AutoDelete,
+			Interface:  attachedDisk.Interface,
+			DevicePath: DevicePathPrefix +
+				attachedDisk.DeviceName,
+		})
+	}
+
+	return vmResponse, nil
+}
+
+// AddEndpoints adds new endpoints to the given firewall
+func (vm *VM) AddEndpoints() error {
+	s, err := vm.getService()
+	if err != nil {
+		return err
+	}
+	return s.addFirewallPorts()
+}
+
+// RemoveEndpoints removes given endpoints from the given firewall
+func (vm *VM) RemoveEndpoints() error {
+	s, err := vm.getService()
+	if err != nil {
+		return err
+	}
+	return s.removeFirewallPorts()
+}
+
+// GetImageList lists images available in given projects
+func (vm *VM) GetImageList() ([]Image, error) {
+	s, err := vm.getService()
+	if err != nil {
+		return nil, err
+	}
+
+	imageList, err := s.getImageList()
+	if err != nil {
+		return nil, err
+	}
+
+	response := make([]Image, 0)
+
+	for _, image := range imageList {
+		depStatus := ""
+		depReplacement := ""
+		if image.Deprecated != nil {
+			depStatus = image.Deprecated.State
+			depReplacement = image.Deprecated.Replacement
+		}
+
+		response = append(response, Image{
+			Name:                   image.Name,
+			Description:            image.Description,
+			Status:                 image.Status,
+			Id:                     image.Id,
+			DeprecationStatus:      depStatus,
+			DeprecationReplacement: depReplacement,
+			CreationTimestamp:      image.CreationTimestamp,
+			DiskSizeGb:             image.DiskSizeGb,
+			Family:                 image.Family,
+		})
+	}
+
+	return response, nil
 }

--- a/virtualmachine/gcp/vm.go
+++ b/virtualmachine/gcp/vm.go
@@ -10,7 +10,6 @@ import (
 	"github.com/apcera/libretto/ssh"
 	"github.com/apcera/libretto/util"
 	"github.com/apcera/libretto/virtualmachine"
-	"strings"
 )
 
 const (
@@ -528,12 +527,6 @@ func (vm *VM) GetRegionList() ([]Region, error) {
 	}
 
 	return response, nil
-}
-
-// convResURLToName returns resource name from the given resource URL
-func convResURLToName(url string) string {
-	urlSplit := strings.Split(url, "/")
-	return urlSplit[len(urlSplit)-1]
 }
 
 // AddNewDisks adds a new disks to an instance


### PR DESCRIPTION
**Jira id**
[MRPHS-3461](https://apporbit.atlassian.net/browse/MRPHS-3461)

**Problem**
Libretto does not have support for actions such as reseting a VM, adding and deleting disks, updating firewall rules, obtaining lists of network, subnet, machine types, regions, zones, disk types and images. 

**Solution**
Support has been added with new function given below. The existing framework of in this library is extended by writing receiver functions in vm.go and they in-turn call the functions in util.go which interact with GCP SDK. New structs are defined for network, subnetwork, machine type, disk type, zone, region, firewall and endpoints. The functions return requested information back to the caller with these structs. 

- Reset
- GetNetworkList
- GetSubnetworkList
- GetMachineTypeList
- GetDiskTypeList
- GetZoneList
- GetRegionList
- AddNewDisks
- DeleteVMDisks
- GetInstance
- AddEndpoints
- RemoveEndpoints
- GetImageList

**Unit Testing**
Testing of these functions performed with various input parameters. The log of the test conducted with a dummy client that calls all the functions is given below:

```json
Network list retrieved successfully
[{"name":"default","description":"Default network for the project","id":"3872013564795146435","auto_create_subnetworks":true,"creation_timestamp":"2017-09-11T04:06:20.428-07:00","subnetworks":["default","default","default","default","default","default","default","default","default","default","default","default"]},{"name":"libretto","description":"libretto-test","id":"6576496738135487693","auto_create_subnetworks":false,"creation_timestamp":"2017-09-13T03:36:18.302-07:00","subnetworks":["sub-us-west1","sub1"]}]
Image list retrieved successfully
[{"id":"4568702763004249623","creation_timestamp":"2014-09-04T09:50:19.966-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20140924","description":"CentOS 7.0 x86_64 built on 2014-09-03","disk_size_gb":"10","name":"centos-7-v20140903","status":"READY"},{"id":"4822681162745636585","creation_timestamp":"2014-09-24T19:57:13.650-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20140926","description":"CentOS 7 x86_64 built on 2014-09-24","disk_size_gb":"10","name":"centos-7-v20140924","status":"READY"},{"id":"11630347837395986864","creation_timestamp":"2014-09-29T09:29:54.626-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20141007","description":"CentOS 7 x86_64 built on 2014-09-26","disk_size_gb":"10","name":"centos-7-v20140926","status":"READY"},{"id":"13420104487111729570","creation_timestamp":"2014-10-16T14:18:33.905-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20141016","description":"CentOS 7.0 x86_64 built on 2014-10-07","disk_size_gb":"10","name":"centos-7-v20141007","status":"READY"},{"id":"4506010319257803087","creation_timestamp":"2014-10-17T16:43:06.539-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20141021","description":"CentOS 7.0 x86_64 built on 2014-10-16","disk_size_gb":"10","name":"centos-7-v20141016","status":"READY"},{"id":"4536638025069785573","creation_timestamp":"2014-10-22T18:27:40.851-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20141108","description":"CentOS 7 x86_64 built on 2014-10-21","disk_size_gb":"10","name":"centos-7-v20141021","status":"READY"},{"id":"853041310537923411","creation_timestamp":"2014-11-10T14:22:16.416-08:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20141205","description":"CentOS 7 x86_64 built on 2014-11-08","disk_size_gb":"10","name":"centos-7-v20141108","status":"READY"},{"id":"9955643093605856709","creation_timestamp":"2014-12-08T16:35:02.271-08:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20141218","description":"CentOS 7 x86_64 built on 2014-12-05","disk_size_gb":"10","name":"centos-7-v20141205","status":"READY"},{"id":"4809836014772868503","creation_timestamp":"2015-01-05T14:54:47.349-08:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20150127","description":"CentOS 7 x86_64 built on 2014-12-18","disk_size_gb":"10","name":"centos-7-v20141218","status":"READY"},{"id":"9812507426971718529","creation_timestamp":"2015-01-28T19:19:09.280-08:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20150226","description":"CentOS 7 x86_64 built on 2015-01-27","disk_size_gb":"10","name":"centos-7-v20150127","status":"READY"},{"id":"848743723932840478","creation_timestamp":"2015-03-03T16:08:17.872-08:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20150309","description":"CentOS 7 x86_64 built on 2015-02-26","disk_size_gb":"10","name":"centos-7-v20150226","status":"READY"},{"id":"2060792561539410536","creation_timestamp":"2015-03-10T13:31:03.109-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20150325","description":"CentOS 7 x86_64 built on 2015-03-09","disk_size_gb":"10","name":"centos-7-v20150309","status":"READY"},{"id":"5754090688068719631","creation_timestamp":"2015-03-27T12:09:20.845-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20150423","description":"CentOS 7 x86_64 built on 2015-03-25","disk_size_gb":"10","name":"centos-7-v20150325","status":"READY"},{"id":"6047445488489148610","creation_timestamp":"2015-04-30T13:18:53.201-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20150526","description":"CentOS, CentOS, 7, x86_64 built on 2015-04-23","disk_size_gb":"10","name":"centos-7-v20150423","status":"READY"},{"id":"2915201787420707637","creation_timestamp":"2015-05-27T14:23:38.886-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20150603","description":"CentOS, CentOS, 7.1.1503, x86_64 built on 2015-05-26","disk_size_gb":"10","name":"centos-7-v20150526","status":"READY"},{"id":"1973199963443338581","creation_timestamp":"2015-06-09T10:34:50.314-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20150710","description":"CentOS, CentOS, 7.1.1503, x86_64 built on 2015-06-03","disk_size_gb":"10","name":"centos-7-v20150603","status":"READY"},{"id":"8297792628255727222","creation_timestamp":"2015-07-13T13:33:29.744-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20150818","description":"CentOS, CentOS, 7.1.1503, x86_64 built on 2015-07-10","disk_size_gb":"10","name":"centos-7-v20150710","status":"READY"},{"id":"6561876587929023862","creation_timestamp":"2015-08-24T14:24:41.898-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20150915","description":"CentOS, CentOS, 7.1.1503, x86_64 built on 2015-08-18","disk_size_gb":"10","name":"centos-7-v20150818","status":"READY"},{"id":"5779912740115484003","creation_timestamp":"2015-09-17T14:41:32.614-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20150929","description":"CentOS, CentOS, 7.1.1503, x86_64 built on 2015-09-15","disk_size_gb":"10","name":"centos-7-v20150915","status":"READY"},{"id":"7716058656801393790","creation_timestamp":"2015-10-06T13:44:01.187-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20151104","description":"CentOS, CentOS, 7.1.1503, x86_64 built on 2015-09-29","disk_size_gb":"10","name":"centos-7-v20150929","status":"READY"},{"id":"8838584153871781432","creation_timestamp":"2015-11-09T15:48:39.859-08:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20160119","description":"CentOS, CentOS, 7.1.1503, x86_64 built on 2015-11-04","disk_size_gb":"10","name":"centos-7-v20151104","status":"READY"},{"id":"8660497917661064586","creation_timestamp":"2016-01-19T20:56:05.273-08:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20160126","description":"CentOS, CentOS, 7.2.1511, x86_64 built on 2016-01-19","disk_size_gb":"10","name":"centos-7-v20160119","status":"READY"},{"id":"5025100056290980886","creation_timestamp":"2016-01-27T14:55:53.533-08:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20160211","description":"CentOS, CentOS, 7.2.1511, x86_64 built on 2016-01-26","disk_size_gb":"10","name":"centos-7-v20160126","status":"READY"},{"id":"54163706009799829","creation_timestamp":"2016-02-16T11:03:22.399-08:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20160216","description":"CentOS, CentOS, 7.2.1511, x86_64 built on 2016-02-11","disk_size_gb":"10","name":"centos-7-v20160211","status":"READY"},{"id":"5307226326143956207","creation_timestamp":"2016-02-17T11:29:04.712-08:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20160219","description":"CentOS, CentOS, 7.2.1511, x86_64 built on 2016-02-16","disk_size_gb":"10","name":"centos-7-v20160216","status":"READY"},{"id":"117817058366250736","creation_timestamp":"2016-02-22T11:23:11.288-08:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20160301","description":"CentOS, CentOS, 7.2.1511, x86_64 built on 2016-02-19","disk_size_gb":"10","name":"centos-7-v20160219","status":"READY"},{"id":"3677031631651851296","creation_timestamp":"2016-03-01T20:57:51.795-08:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20160329","description":"CentOS, CentOS, 7.2.1511, x86_64 built on 2016-03-01","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20160301","status":"READY"},{"id":"5059873404309583251","creation_timestamp":"2016-03-30T10:23:08.878-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20160418","description":"CentOS, CentOS, 7.2.1511, x86_64 built on 2016-03-29","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20160329","status":"READY"},{"id":"2898231190483621856","creation_timestamp":"2016-04-19T10:21:19.403-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20160511","description":"CentOS, CentOS, 7, x86_64 built on 2016-04-18","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20160418","status":"READY"},{"id":"5721431653635153993","creation_timestamp":"2016-05-12T12:51:02.587-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20160606","description":"CentOS, CentOS, 7, x86_64 built on 2016-05-11","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20160511","status":"READY"},{"id":"1889620002910747979","creation_timestamp":"2016-06-09T17:02:44.099-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20160629","description":"CentOS, CentOS, 7, x86_64 built on 2016-06-06","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20160606","status":"READY"},{"id":"2745708994769844877","creation_timestamp":"2016-06-29T14:57:54.595-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20160711","description":"CentOS, CentOS, 7, x86_64 built on 2016-06-29","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20160629","status":"READY"},{"id":"1396713101988499085","creation_timestamp":"2016-07-12T11:01:06.332-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20160718","description":"CentOS, CentOS, 7, x86_64 built on 2016-07-11","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20160711","status":"READY"},{"id":"1351690450177672234","creation_timestamp":"2016-07-18T17:56:37.633-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20160803","description":"CentOS, CentOS, 7, x86_64 built on 2016-07-18","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20160718","status":"READY"},{"id":"7502263907890640569","creation_timestamp":"2016-08-04T11:24:22.175-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20160921","description":"CentOS, CentOS, 7, x86_64 built on 2016-08-03","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20160803","status":"READY"},{"id":"3345701383252326214","creation_timestamp":"2016-09-22T09:41:13.610-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20161025","description":"CentOS, CentOS, 7, x86_64 built on 2016-09-21","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20160921","status":"READY"},{"id":"5235113928293489857","creation_timestamp":"2016-10-25T11:19:26.250-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20161027","description":"CentOS, CentOS, 7, x86_64 built on 2016-10-25","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20161025","status":"READY"},{"id":"4534636931622894250","creation_timestamp":"2016-10-27T11:15:33.312-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20161129","description":"CentOS, CentOS, 7, x86_64 built on 2016-10-27","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20161027","status":"READY"},{"id":"8628576586818627004","creation_timestamp":"2016-11-29T16:20:35.171-08:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20161212","description":"CentOS, CentOS, 7, x86_64 built on 2016-11-29","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20161129","status":"READY"},{"id":"8650499281020268919","creation_timestamp":"2016-12-14T10:29:44.741-08:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20170110","description":"CentOS, CentOS, 7, x86_64 built on 2016-12-12","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20161212","status":"READY"},{"id":"6699622773219337753","creation_timestamp":"2017-01-11T12:43:34.658-08:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20170124","description":"CentOS, CentOS, 7, x86_64 built on 2017-01-10","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20170110","status":"READY"},{"id":"3033065083021971804","creation_timestamp":"2017-01-24T16:22:11.779-08:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20170223","description":"CentOS, CentOS, 7, x86_64 built on 2017-01-24","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20170124","status":"READY"},{"id":"6769386339310909737","creation_timestamp":"2017-02-23T17:09:26.516-08:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20170227","description":"CentOS, CentOS, 7, x86_64 built on 2017-02-23","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20170223","status":"READY"},{"id":"4890196529355931002","creation_timestamp":"2017-02-28T15:11:17.984-08:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20170327","description":"CentOS, CentOS, 7, x86_64 built on 2017-02-27","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20170227","status":"READY"},{"id":"447698369464728900","creation_timestamp":"2017-03-28T13:12:27.756-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20170426","description":"CentOS, CentOS, 7, x86_64 built on 2017-03-27","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20170327","status":"READY"},{"id":"5992902547674756879","creation_timestamp":"2017-04-27T12:43:28.666-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20170523","description":"CentOS, CentOS, 7, x86_64 built on 2017-04-26","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20170426","status":"READY"},{"id":"8171633968241181019","creation_timestamp":"2017-05-24T10:15:32.130-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20170616","description":"CentOS, CentOS, 7, x86_64 built on 2017-05-23","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20170523","status":"READY"},{"id":"3466558228180352098","creation_timestamp":"2017-06-19T09:57:49.783-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20170620","description":"CentOS, CentOS, 7, x86_64 built on 2017-06-16","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20170616","status":"READY"},{"id":"5221862210449711470","creation_timestamp":"2017-06-20T15:19:45.383-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20170717","description":"CentOS, CentOS, 7, x86_64 built on 2017-06-20","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20170620","status":"READY"},{"id":"4829074772484947680","creation_timestamp":"2017-07-18T10:06:23.083-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20170719","description":"CentOS, CentOS, 7, x86_64 built on 2017-07-17","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20170717","status":"READY"},{"id":"9168785680564903962","creation_timestamp":"2017-07-19T15:36:37.572-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20170816","description":"CentOS, CentOS, 7, x86_64 built on 2017-07-19","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20170719","status":"READY"},{"id":"954560959160536305","creation_timestamp":"2017-08-17T12:44:30.189-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20170829","description":"CentOS, CentOS, 7, x86_64 built on 2017-08-16","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20170816","status":"READY"},{"id":"4960063913426897282","creation_timestamp":"2017-08-30T10:35:41.988-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20170918","description":"CentOS, CentOS, 7, x86_64 built on 2017-08-29","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20170829","status":"READY"},{"id":"5203558034783920875","creation_timestamp":"2017-09-19T11:03:48.980-07:00","deprecation_status":"DEPRECATED","deprecation_replacement":"https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20171003","description":"CentOS, CentOS, 7, x86_64 built on 2017-09-18","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20170918","status":"READY"},{"id":"8193040493265699771","creation_timestamp":"2017-10-03T14:12:53.221-07:00","description":"CentOS, CentOS, 7, x86_64 built on 2017-10-03","disk_size_gb":"10","family":"centos-7","name":"centos-7-v20171003","status":"READY"}]
Subnetwork list retrieved successfully
[{"name":"default","id":"1430717182670262494","creation_timestamp":"2017-09-11T04:06:25.514-07:00","gateway_address":"10.128.0.1","network":"default","region":"us-central1","ipv4_range":"10.128.0.0/20"},{"name":"sub1","id":"9010663040757314755","creation_timestamp":"2017-09-13T03:36:28.340-07:00","gateway_address":"10.0.0.1","network":"libretto","region":"us-central1","ipv4_range":"10.0.0.0/9"}]
Flavor list retrieved successfully
[{"name":"f1-micro","description":"1 vCPU (shared physical core) and 0.6 GB RAM","cpus":1,"memory_mb":614,"is_shared_cpu":true,"max_persistent_disks":16,"max_persistent_disks_size_gb":"3072"},{"name":"g1-small","description":"1 vCPU (shared physical core) and 1.7 GB RAM","cpus":1,"memory_mb":1740,"is_shared_cpu":true,"max_persistent_disks":16,"max_persistent_disks_size_gb":"3072"},{"name":"n1-standard-1","description":"1 vCPU, 3.75 GB RAM","cpus":1,"memory_mb":3840,"is_shared_cpu":false,"max_persistent_disks":32,"max_persistent_disks_size_gb":"65536"},{"name":"n1-standard-2","description":"2 vCPUs, 7.5 GB RAM","cpus":2,"memory_mb":7680,"is_shared_cpu":false,"max_persistent_disks":64,"max_persistent_disks_size_gb":"65536"},{"name":"n1-standard-4","description":"4 vCPUs, 15 GB RAM","cpus":4,"memory_mb":15360,"is_shared_cpu":false,"max_persistent_disks":64,"max_persistent_disks_size_gb":"65536"},{"name":"n1-standard-8","description":"8 vCPUs, 30 GB RAM","cpus":8,"memory_mb":30720,"is_shared_cpu":false,"max_persistent_disks":128,"max_persistent_disks_size_gb":"65536"},{"name":"n1-standard-16","description":"16 vCPUs, 60 GB RAM","cpus":16,"memory_mb":61440,"is_shared_cpu":false,"max_persistent_disks":128,"max_persistent_disks_size_gb":"65536"},{"name":"n1-standard-32","description":"32 vCPUs, 120 GB RAM","cpus":32,"memory_mb":122880,"is_shared_cpu":false,"max_persistent_disks":128,"max_persistent_disks_size_gb":"65536"},{"name":"n1-standard-64","description":"64 vCPUs, 240 GB RAM","cpus":64,"memory_mb":245760,"is_shared_cpu":false,"max_persistent_disks":128,"max_persistent_disks_size_gb":"65536"},{"name":"n1-standard-96","description":"96 vCPUs, 360 GB RAM","cpus":96,"memory_mb":368640,"is_shared_cpu":false,"max_persistent_disks":128,"max_persistent_disks_size_gb":"65536"},{"name":"n1-highcpu-2","description":"2 vCPUs, 1.8 GB RAM","cpus":2,"memory_mb":1843,"is_shared_cpu":false,"max_persistent_disks":64,"max_persistent_disks_size_gb":"65536"},{"name":"n1-highcpu-4","description":"4 vCPUs, 3.6 GB RAM","cpus":4,"memory_mb":3686,"is_shared_cpu":false,"max_persistent_disks":64,"max_persistent_disks_size_gb":"65536"},{"name":"n1-highcpu-8","description":"8 vCPUs, 7.2 GB RAM","cpus":8,"memory_mb":7373,"is_shared_cpu":false,"max_persistent_disks":128,"max_persistent_disks_size_gb":"65536"},{"name":"n1-highcpu-16","description":"16 vCPUs, 14.4 GB RAM","cpus":16,"memory_mb":14746,"is_shared_cpu":false,"max_persistent_disks":128,"max_persistent_disks_size_gb":"65536"},{"name":"n1-highcpu-32","description":"32 vCPUs, 28.8 GB RAM","cpus":32,"memory_mb":29491,"is_shared_cpu":false,"max_persistent_disks":128,"max_persistent_disks_size_gb":"65536"},{"name":"n1-highcpu-64","description":"64 vCPUs, 57.6 GB RAM","cpus":64,"memory_mb":58982,"is_shared_cpu":false,"max_persistent_disks":128,"max_persistent_disks_size_gb":"65536"},{"name":"n1-highcpu-96","description":"96 vCPUs, 86 GB RAM","cpus":96,"memory_mb":88474,"is_shared_cpu":false,"max_persistent_disks":128,"max_persistent_disks_size_gb":"65536"},{"name":"n1-highmem-2","description":"2 vCPUs, 13 GB RAM","cpus":2,"memory_mb":13312,"is_shared_cpu":false,"max_persistent_disks":64,"max_persistent_disks_size_gb":"65536"},{"name":"n1-highmem-4","description":"4 vCPUs, 26 GB RAM","cpus":4,"memory_mb":26624,"is_shared_cpu":false,"max_persistent_disks":64,"max_persistent_disks_size_gb":"65536"},{"name":"n1-highmem-8","description":"8 vCPUs, 52 GB RAM","cpus":8,"memory_mb":53248,"is_shared_cpu":false,"max_persistent_disks":128,"max_persistent_disks_size_gb":"65536"},{"name":"n1-highmem-16","description":"16 vCPUs, 104 GB RAM","cpus":16,"memory_mb":106496,"is_shared_cpu":false,"max_persistent_disks":128,"max_persistent_disks_size_gb":"65536"},{"name":"n1-highmem-32","description":"32 vCPUs, 208 GB RAM","cpus":32,"memory_mb":212992,"is_shared_cpu":false,"max_persistent_disks":128,"max_persistent_disks_size_gb":"65536"},{"name":"n1-highmem-64","description":"64 vCPUs, 416 GB RAM","cpus":64,"memory_mb":425984,"is_shared_cpu":false,"max_persistent_disks":128,"max_persistent_disks_size_gb":"65536"},{"name":"n1-highmem-96","description":"96 vCPUs, 624 GB RAM","cpus":96,"memory_mb":638976,"is_shared_cpu":false,"max_persistent_disks":128,"max_persistent_disks_size_gb":"65536"}]
Storage type list retrieved successfully
[{"name":"pd-standard","description":"Standard Persistent Disk","valid_size":"10GB-65536GB","default_disk_size_gb":"500"},{"name":"pd-ssd","description":"SSD Persistent Disk","valid_size":"10GB-65536GB","default_disk_size_gb":"100"},{"name":"local-ssd","description":"Local SSD","valid_size":"375GB-375GB","default_disk_size_gb":"375"}]
Zone list retrieved successfully
[{"name":"asia-east1-c","description":"asia-east1-c","region":"asia-east1","status":"UP"},{"name":"asia-east1-a","description":"asia-east1-a","region":"asia-east1","status":"UP"},{"name":"asia-east1-b","description":"asia-east1-b","region":"asia-east1","status":"UP"},{"name":"asia-northeast1-b","description":"asia-northeast1-b","region":"asia-northeast1","status":"UP"},{"name":"asia-northeast1-a","description":"asia-northeast1-a","region":"asia-northeast1","status":"UP"},{"name":"asia-northeast1-c","description":"asia-northeast1-c","region":"asia-northeast1","status":"UP"},{"name":"asia-southeast1-b","description":"asia-southeast1-b","region":"asia-southeast1","status":"UP"},{"name":"asia-southeast1-a","description":"asia-southeast1-a","region":"asia-southeast1","status":"UP"},{"name":"australia-southeast1-b","description":"australia-southeast1-b","region":"australia-southeast1","status":"UP"},{"name":"australia-southeast1-a","description":"australia-southeast1-a","region":"australia-southeast1","status":"UP"},{"name":"australia-southeast1-c","description":"australia-southeast1-c","region":"australia-southeast1","status":"UP"},{"name":"europe-west1-d","description":"europe-west1-d","region":"europe-west1","status":"UP"},{"name":"europe-west1-b","description":"europe-west1-b","region":"europe-west1","status":"UP"},{"name":"europe-west1-c","description":"europe-west1-c","region":"europe-west1","status":"UP"},{"name":"europe-west2-a","description":"europe-west2-a","region":"europe-west2","status":"UP"},{"name":"europe-west2-b","description":"europe-west2-b","region":"europe-west2","status":"UP"},{"name":"europe-west2-c","description":"europe-west2-c","region":"europe-west2","status":"UP"},{"name":"europe-west3-b","description":"europe-west3-b","region":"europe-west3","status":"UP"},{"name":"europe-west3-a","description":"europe-west3-a","region":"europe-west3","status":"UP"},{"name":"europe-west3-c","description":"europe-west3-c","region":"europe-west3","status":"UP"},{"name":"southamerica-east1-c","description":"southamerica-east1-c","region":"southamerica-east1","status":"UP"},{"name":"southamerica-east1-b","description":"southamerica-east1-b","region":"southamerica-east1","status":"UP"},{"name":"southamerica-east1-a","description":"southamerica-east1-a","region":"southamerica-east1","status":"UP"},{"name":"us-central1-a","description":"us-central1-a","region":"us-central1","status":"UP"},{"name":"us-central1-b","description":"us-central1-b","region":"us-central1","status":"UP"},{"name":"us-central1-f","description":"us-central1-f","region":"us-central1","status":"UP"},{"name":"us-central1-c","description":"us-central1-c","region":"us-central1","status":"UP"},{"name":"us-east1-b","description":"us-east1-b","region":"us-east1","status":"UP"},{"name":"us-east1-c","description":"us-east1-c","region":"us-east1","status":"UP"},{"name":"us-east1-d","description":"us-east1-d","region":"us-east1","status":"UP"},{"name":"us-east4-c","description":"us-east4-c","region":"us-east4","status":"UP"},{"name":"us-east4-a","description":"us-east4-a","region":"us-east4","status":"UP"},{"name":"us-east4-b","description":"us-east4-b","region":"us-east4","status":"UP"},{"name":"us-west1-b","description":"us-west1-b","region":"us-west1","status":"UP"},{"name":"us-west1-a","description":"us-west1-a","region":"us-west1","status":"UP"},{"name":"us-west1-c","description":"us-west1-c","region":"us-west1","status":"UP"}]
Region list retrieved successfully
[{"name":"us-central1","description":"us-central1","zones":["us-central1-a","us-central1-b","us-central1-c","us-central1-f"],"status":"UP"},{"name":"europe-west1","description":"europe-west1","zones":["europe-west1-b","europe-west1-c","europe-west1-d"],"status":"UP"},{"name":"us-west1","description":"us-west1","zones":["us-west1-a","us-west1-b","us-west1-c"],"status":"UP"},{"name":"asia-east1","description":"asia-east1","zones":["asia-east1-a","asia-east1-b","asia-east1-c"],"status":"UP"},{"name":"us-east1","description":"us-east1","zones":["us-east1-b","us-east1-c","us-east1-d"],"status":"UP"},{"name":"asia-northeast1","description":"asia-northeast1","zones":["asia-northeast1-a","asia-northeast1-b","asia-northeast1-c"],"status":"UP"},{"name":"asia-southeast1","description":"asia-southeast1","zones":["asia-southeast1-a","asia-southeast1-b"],"status":"UP"},{"name":"us-east4","description":"us-east4","zones":["us-east4-a","us-east4-b","us-east4-c"],"status":"UP"},{"name":"australia-southeast1","description":"australia-southeast1","zones":["australia-southeast1-c","australia-southeast1-a","australia-southeast1-b"],"status":"UP"},{"name":"europe-west2","description":"europe-west2","zones":["europe-west2-a","europe-west2-b","europe-west2-c"],"status":"UP"},{"name":"europe-west3","description":"europe-west3","zones":["europe-west3-c","europe-west3-a","europe-west3-b"],"status":"UP"},{"name":"southamerica-east1","description":"southamerica-east1","zones":["southamerica-east1-a","southamerica-east1-b","southamerica-east1-c"],"status":"UP"}]
Adding endpoints
Endpoints added successfully
{"ret":0,"ret_str":"Success"}
Sleeping for 10 seconds
Removing endpoints
Endpoints removed successfully
{"ret":0,"ret_str":"Success"}
Sleeping for 10 seconds
Creating instance
Instance created successfully
{"name":"ao-vm-1","id":"8513068896015646583","status":"RUNNING","creation_timestamp":"2017-10-11T00:00:41.433-07:00","private_ipv4":"10.0.0.2","public_ipv4":"35.188.69.188","volumes":[{"name":"persistent-disk-0","device_path":"/dev/disk/by-id/google-persistent-disk-0","boot":true,"auto_delete":true,"interface":"SCSI"},{"name":"additional-disk","device_path":"/dev/disk/by-id/google-additional-disk","boot":false,"auto_delete":true,"interface":"SCSI"}]}
Sleeping for 10 seconds
Adding volumes
Volumes added successfully
[{"name":"newdisk-1","device_path":"/dev/disk/by-id/google-newdisk-1","boot":false,"auto_delete":true,"interface":"SCSI"},{"name":"newdisk-2","device_path":"/dev/disk/by-id/google-newdisk-2","boot":false,"auto_delete":true,"interface":"SCSI"}]
Sleeping for 10 seconds
Removing volume
Volume deleted successfully
{"ret":0,"ret_str":"Success"}
Sleeping for 10 seconds
Stopping instance
Instance stopped successfully
{"ret":0,"ret_str":"Success"}
Sleeping for 10 seconds
Starting instance
Instance started successfully
{"ret":0,"ret_str":"Success"}
Sleeping for 10 seconds
Resetting instance
Instance reset successfully
{"ret":0,"ret_str":"Success"}
Sleeping for 10 seconds
Deleting instance
Instance deleted successfully
{"ret":0,"ret_str":"Success"}

Process finished with exit code 0
```