### PR TITLE
MRPHS-3480  : Support GetVMInfo for multiple VMs

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -399,7 +399,7 @@ func searchTree(vm *VM, mor types.ManagedObjectReference, name string) (*mo.Virt
 	case "VirtualMachine":
 		// Base recursive case, compare for value
 		vmMo := mo.VirtualMachine{}
-		err := vm.collector.RetrieveOne(vm.ctx, mor, []string{"name", "config", "guest.ipAddress", "guest.guestState", "guest.net", "runtime.question", "snapshot.currentSnapshot", "guest.toolsRunningStatus", "summary.quickStats"}, &vmMo)
+		err := vm.collector.RetrieveOne(vm.ctx, mor, []string{"name", "config", "guest.ipAddress", "guest.guestState", "guest.net", "runtime.question", "snapshot.currentSnapshot", "guest.toolsRunningStatus", "summary", "runtime"}, &vmMo)
 		if err != nil {
 			return nil, NewErrorObjectNotFound(errors.New("could not find the vm"), name)
 		}

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -470,6 +470,10 @@ type VMInfo struct {
 	ToolsRunningStatus string
 	OverallCpuUsage    int64
 	GuestMemoryUsage   int64
+	MaxCpuUsage        int32
+	MaxMemoryUsage     int32
+	NumCpu             int32
+	PowerState         string
 }
 
 type Flavor struct {
@@ -876,6 +880,10 @@ func (vm *VM) GetVMInfo() (VMInfo, error) {
 	vmInfo.ToolsRunningStatus = toolsRunningStatus
 	vmInfo.OverallCpuUsage = int64(vmMo.Summary.QuickStats.OverallCpuUsage)
 	vmInfo.GuestMemoryUsage = int64(vmMo.Summary.QuickStats.GuestMemoryUsage)
+	vmInfo.MaxCpuUsage = vmMo.Runtime.MaxCpuUsage
+	vmInfo.MaxMemoryUsage = vmMo.Runtime.MaxMemoryUsage
+	vmInfo.PowerState = string(vmMo.Runtime.PowerState)
+	vmInfo.NumCpu = vmMo.Summary.Config.NumCpu
 
 	return vmInfo, nil
 }


### PR DESCRIPTION
### Symptom:
https://apporbit.atlassian.net/browse/MRPHS-3480

 

### Description:
Platform may need to fetch the statuses of multiple VMs from a vcenter. A single API call to c3ntry is needed because otherwise the number of connection setup/tear-down will be linear and will scale very poorly.

### Resolution:
Added code for sending info MaxCpuUsage ,MaxMemoryUsage , NumCpu, PowerState.

### Testing:
**Unit Testing:**
```
[root@deepali-dev3 appos]#  go run src/appos/c3ntryrpc/example/c3ntry_client.go
Sending request:
action:"get_vm_info" args:"{\"cloud_type\":\"vsphere\", \"Host\":\"209.205.216.11\",\"Username\":\"deepali@vsphere.local\",\"Password\":\"D33p@li@$Dogreat12\",\"Insecure\":true, \"VMs\": [{\"Name\":\"sumeet-macvtap-test2\", \"Datacenter\":\"developer-lab\"}, {\"Name\":\"Deepali_Test_vm\", \"Datacenter\":\"developer-lab\"}]}"

2017/10/24 06:08:39 Received Response:
result:"{\"VMs\":[{\"datacenter\":\"developer-lab\",\"guestMemoryUsage\":81,\"ipAddress\":[\"67.220.185.198\",\"fe80::250:56ff:fe89:3c60\",\"fe80::1846:bff:feca:bc7c\",\"172.17.0.1\"],\"toolsRunningStatus\":\"guestToolsRunning\",\"vMId\":\"vm-4984\",\"name\":\"sumeet-macvtap-test2\",\"maxMemoryUsage\":4096,\"maxCpuUsage\":7006,\"numCpu\":2,\"powerstate\":\"poweredOn\"},{\"datacenter\":\"developer-lab\",\"toolsRunningStatus\":\"guestToolsNotRunning\",\"vMId\":\"vm-5145\",\"name\":\"Deepali_Test_vm\",\"maxMemoryUsage\":2048,\"maxCpuUsage\":3503,\"numCpu\":1,\"powerstate\":\"poweredOff\"}]}" progress:100

2017/10/24 06:08:39 Response String:
{"result":"{\"VMs\":[{\"datacenter\":\"developer-lab\",\"guestMemoryUsage\":81,\"ipAddress\":[\"67.220.185.198\",\"fe80::250:56ff:fe89:3c60\",\"fe80::1846:bff:feca:bc7c\",\"172.17.0.1\"],\"toolsRunningStatus\":\"guestToolsRunning\",\"vMId\":\"vm-4984\",\"name\":\"sumeet-macvtap-test2\",\"maxMemoryUsage\":4096,\"maxCpuUsage\":7006,\"numCpu\":2,\"powerstate\":\"poweredOn\"},{\"datacenter\":\"developer-lab\",\"toolsRunningStatus\":\"guestToolsNotRunning\",\"vMId\":\"vm-5145\",\"name\":\"Deepali_Test_vm\",\"maxMemoryUsage\":2048,\"maxCpuUsage\":3503,\"numCpu\":1,\"powerstate\":\"poweredOff\"}]}","progress":100}

2017/10/24 06:08:39 Breaking..
