### PR TITLE
MRPHS-3528: Provide support to create and delete images in GCP

### DIFF
--- a/virtualmachine/gcp/util.go
+++ b/virtualmachine/gcp/util.go
@@ -37,7 +37,7 @@ type googleService struct {
 type googleResManService struct {
 	// account represents the Google cloud account that is used to make
 	// calls to Google cloud resource manager APIs.
-	account     *Account
+	account *Account
 	// service: represents an object that contains an http client that is
 	// used to make calls to Google cloud resource manager APIs.
 	service *googleresourcemanager.Service
@@ -790,4 +790,30 @@ func (svc *googleResManService) getProjectList() ([]*googleresourcemanager.Proje
 	}
 
 	return projectList.Projects, nil
+}
+
+// createImage creates a new image in Google cloud platform from a raw disk
+// image stored on Google Cloud Storage.
+func (svc *googleService) createImage() error {
+	image := &googlecloud.Image{
+		Name:        svc.vm.SourceImage,
+		Description: svc.vm.Description,
+		RawDisk: &googlecloud.ImageRawDisk{
+			Source: svc.vm.RawDiskSource,
+		},
+	}
+	op, err := svc.service.Images.Insert(svc.vm.Project, image).Do()
+	if err != nil {
+		return err
+	}
+	return svc.waitForGlobalOperationReady(op.Name)
+}
+
+// deleteImage deletes an image from Google cloud platform
+func (svc *googleService) deleteImage() error {
+	op, err := svc.service.Images.Delete(svc.vm.Project, svc.vm.SourceImage).Do()
+	if err != nil {
+		return err
+	}
+	return svc.waitForGlobalOperationReady(op.Name)
 }

--- a/virtualmachine/gcp/vm.go
+++ b/virtualmachine/gcp/vm.go
@@ -4,13 +4,13 @@ package gcp
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"time"
 
 	"github.com/apcera/libretto/ssh"
 	"github.com/apcera/libretto/util"
 	"github.com/apcera/libretto/virtualmachine"
-	"fmt"
 )
 
 const (
@@ -70,6 +70,11 @@ type VM struct {
 
 	Firewall  string // required when modifying firewall rules
 	Endpoints []Endpoint
+
+	// RawDiskSource is the full Google Cloud Storage URL ere the raw disk
+	// image is stored. It is required only for creating a new image from
+	// a raw disk.
+	RawDiskSource string
 }
 
 // Endpoint represents the protocol and ports configured in a firewall
@@ -735,4 +740,24 @@ func (acc *Account) GetProjectList() ([]Project, error) {
 	}
 
 	return response, nil
+}
+
+// CreateImage: Creates a new image from raw disk
+func (vm *VM) CreateImage() error {
+	s, err := vm.getService()
+	if err != nil {
+		return err
+	}
+
+	return s.createImage()
+}
+
+// DeleteImage: Deletes an image
+func (vm *VM) DeleteImage() error {
+	s, err := vm.getService()
+	if err != nil {
+		return err
+	}
+
+	return s.deleteImage()
 }

--- a/virtualmachine/gcp/vm.go
+++ b/virtualmachine/gcp/vm.go
@@ -71,7 +71,7 @@ type VM struct {
 	Firewall  string // required when modifying firewall rules
 	Endpoints []Endpoint
 
-	// RawDiskSource is the full Google Cloud Storage URL ere the raw disk
+	// RawDiskSource is the full Google Cloud Storage URL where the raw disk
 	// image is stored. It is required only for creating a new image from
 	// a raw disk.
 	RawDiskSource string


### PR DESCRIPTION
### JIRA Id

[MRPHS-3528](https://apporbit.atlassian.net/browse/MRPHS-3528)

### Problem

Libretto currently does not provide functions to create and delete images in GCP.

### Solution

One of the ways to create a custom image in Google Compute Engine is to upload a compressed (tar.gz format) raw disk image file (with name disk.raw) to Google Cloud Storage and create a Google Compute Engine compatible image from that raw disk. Please refer to the complete process at: https://cloud.google.com/compute/docs/images/import-existing-image

Through this PR, Libretto is going to provide a function with which a compressed raw disk available on Google Cloud Storage can be used to create a custom image in Google Compute Engine. This custom image can then be used to launch instances in Google Compute Engine. The input required is the path of the raw disk on Google Cloud Storage, the name you want to give to the image and your project ID.

A function is also being provided to delete a custom image from Google Compute Engine. The input required is your project ID and the image name.

### Unit Testing

Unit testing has been done to create and delete an image. The output of a dummy client is given below:

Create Image:
```
time="2017-10-25T16:26:21+05:30" level=debug msg="[actions.go:29::github.com/jayant-izel/halo.glob..func1] Providing a gcp cloud-object instance"
time="2017-10-25T16:26:21+05:30" level=debug msg="[gcp.go:995::github.com/jayant-izel/halo/cloud/gcp.(*Cloud).CreateImage] Creating a new GCP image, input: {
  "AccountFile": "/root/gcp-libretto.json",
  "Project": "useful-song-179609",
  "SourceImage": "ubuntu-1604",
  "Description": "Ubuntu 16.04 image",
  "RawDiskSource": "https://storage.googleapis.com/aobucket/ubuntu1604-gce.tar.gz",
  "Scopes": [
    "https://www.googleapis.com/auth/compute",
    "https://www.googleapis.com/auth/devstorage.full_control"
  ]
}"
time="2017-10-25T16:26:21+05:30" level=debug msg="[gcp.go:1009::github.com/jayant-izel/halo/cloud/gcp.(*Cloud).CreateImage] Calling Libretto->vm.CreateImage()"
time="2017-10-25T16:28:48+05:30" level=debug msg="[gcp.go:1015::github.com/jayant-izel/halo/cloud/gcp.(*Cloud).CreateImage] Image ubuntu-1604 created successfully"
```

Delete Image:
```
time="2017-10-25T16:29:38+05:30" level=debug msg="[actions.go:29::github.com/jayant-izel/halo.glob..func1] Providing a gcp cloud-object instance"
time="2017-10-25T16:29:38+05:30" level=debug msg="[gcp.go:1022::github.com/jayant-izel/halo/cloud/gcp.(*Cloud).DeleteImage] Deleting GCP image, input: {
  "AccountFile": "/root/gcp-libretto.json",
  "Project": "useful-song-179609",
  "SourceImage": "ubuntu-1604",
  "Scopes": [
    "https://www.googleapis.com/auth/compute"
  ]
}"
time="2017-10-25T16:29:38+05:30" level=debug msg="[gcp.go:1036::github.com/jayant-izel/halo/cloud/gcp.(*Cloud).DeleteImage] Calling Libretto->vm.DeleteImage()"
time="2017-10-25T16:30:51+05:30" level=debug msg="[gcp.go:1042::github.com/jayant-izel/halo/cloud/gcp.(*Cloud).DeleteImage] Image ubuntu-1604 deleted successfully"
```

### Addition Notes:
NA