### PR TITLE
MRPHS-3456 : Convert vm to template, shutdown instead of power off

### DIFF
--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -1617,7 +1617,7 @@ func ConvertToTemplate(vm *VM) error {
 		return fmt.Errorf("error getting the uploaded VM: %v", err)
 	}
 
-	err = halt(vm)
+	err = shutDown(vm)
 	if err != nil {
 		return fmt.Errorf("error halting the VM: %v", err)
 	}


### PR DESCRIPTION
**Jira-id**

MRPHS-3456

**Problem**

Converting template after powering off the vm spoils the template. Need to gracefully shutdown the vm before converting to template.

**Solution**

Shutdown the vm gracefully instead of powering off the vm.

**Unit Testing**

Done. Tried creating vm template. Created vms from the template and created custom cluster on the vms. The cluster is deployed successfully.