### PR TITLE
MRPHS-3538 : guestToolsRunningStatus string should returns as boolean

### DIFF
--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -879,12 +879,10 @@ func (vm *VM) Destroy() (err error) {
 
 //getToolsRunningStatus returns ToolsRunningState as true/false
 func getToolsRunningStatus(status string) bool {
-	ret := false
 	if string(types.VirtualMachineToolsRunningStatusGuestToolsRunning) == status {
-		ret = true
+		return true
 	}
-	return ret
-
+	return false
 }
 
 //GetVMInfo returns information of this VM.

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -473,7 +473,7 @@ type VirtualEthernetCard struct {
 type VMInfo struct {
 	VMId               string
 	IpAddress          []net.IP
-	ToolsRunningStatus string
+	ToolsRunningStatus bool
 	OverallCpuUsage    int64
 	GuestMemoryUsage   int64
 	MaxCpuUsage        int32
@@ -877,6 +877,16 @@ func (vm *VM) Destroy() (err error) {
 	return nil
 }
 
+//getToolsRunningStatus returns ToolsRunningState as true/false
+func getToolsRunningStatus(status string) bool {
+	ret := false
+	if string(types.VirtualMachineToolsRunningStatusGuestToolsRunning) == status {
+		ret = true
+	}
+	return ret
+
+}
+
 //GetVMInfo returns information of this VM.
 func (vm *VM) GetVMInfo() (VMInfo, error) {
 	var vmInfo VMInfo
@@ -896,7 +906,7 @@ func (vm *VM) GetVMInfo() (VMInfo, error) {
 	}
 
 	ips, vmid, err := vm.GetIPsAndId()
-	toolsRunningStatus := vmMo.Guest.ToolsRunningStatus
+	toolsRunningStatus := getToolsRunningStatus(vmMo.Guest.ToolsRunningStatus)
 
 	vmInfo.VMId = vmid
 	vmInfo.IpAddress = ips


### PR DESCRIPTION
### Symptom:
https://apporbit.atlassian.net/browse/MRPHS-3538


### Description:
Platform required vmware guest tools running status as boolean instead of string.

### Testing:

**Unit Testing:**
```
[root@deepali-dev3 appos]# go run src/appos/c3ntryrpc/example/c3ntry_client.go
Sending request:
action:"get_vm_info" args:"{\"cloud_type\":\"vsphere\", \"Host\":\"209.205.216.11\",\"Username\":\"deepali@vsphere.local\",\"Password\":\"D33p@li@$Dogreat12\",\"Insecure\":true, \"VMs\": [{\"Name\":\"sumeet-macvtap-test2\", \"Datacenter\":\"developer-lab\"}, {\"Name\":\"pin-win10\", \"Datacenter\":\"developer-lab\"}]}"

2017/10/26 12:19:50 Received Response:
result:"{\"VMs\":[{\"datacenter\":\"developer-lab\",\"guestMemoryUsage\":122,\"ipAddress\":[\"67.220.185.198\",\"fe80::250:56ff:fe89:3c60\",\"fe80::1846:bff:feca:bc7c\",\"172.17.0.1\"],\"toolsRunningStatus\":true,\"vmId\":\"vm-4984\",\"name\":\"sumeet-macvtap-test2\",\"maxMemoryUsage\":4096,\"maxCpuUsage\":7006,\"numCpu\":2,\"powerstate\":\"poweredOn\"},{\"datacenter\":\"developer-lab\",\"toolsRunningStatus\":false,\"vmId\":\"vm-18\",\"name\":\"pin-win10\",\"numCpu\":2,\"powerstate\":\"poweredOff\"}]}" progress:100

2017/10/26 12:19:50 Response String:
{"result":"{\"VMs\":[{\"datacenter\":\"developer-lab\",\"guestMemoryUsage\":122,\"ipAddress\":[\"67.220.185.198\",\"fe80::250:56ff:fe89:3c60\",\"fe80::1846:bff:feca:bc7c\",\"172.17.0.1\"],\"toolsRunningStatus\":true,\"vmId\":\"vm-4984\",\"name\":\"sumeet-macvtap-test2\",\"maxMemoryUsage\":4096,\"maxCpuUsage\":7006,\"numCpu\":2,\"powerstate\":\"poweredOn\"},{\"datacenter\":\"developer-lab\",\"toolsRunningStatus\":false,\"vmId\":\"vm-18\",\"name\":\"pin-win10\",\"numCpu\":2,\"powerstate\":\"poweredOff\"}]}","progress":100}

2017/10/26 12:19:50 Breaking..
