### PR TITLE
MRPHS-3648 : Support for handling host drs enabled clusters

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -59,3 +59,13 @@ func CombineErrors(delimiter string, errs ...error) error {
 
 	return fmt.Errorf(strings.Join(formatStrs, delimiter))
 }
+
+// ChooseRandomString: returns a random string from slice of string
+func ChooseRandomString(from []string) string {
+	lenFrom := len(from)
+	if lenFrom != 0 {
+		n := Random(0, lenFrom-1)
+		return from[n]
+	}
+	return ""
+}

--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -245,7 +245,9 @@ var findClusterComputeResource = func(vm *VM, dc *mo.Datacenter, name string) (*
 		return nil, err
 	}
 	cr := mo.ClusterComputeResource{}
-	err = vm.collector.RetrieveOne(vm.ctx, *mor, []string{"name", "host", "resourcePool", "datastore", "network"}, &cr)
+	err = vm.collector.RetrieveOne(vm.ctx, *mor, []string{"name",
+		"configuration", "host", "resourcePool", "datastore",
+		"network"}, &cr)
 	if err != nil {
 		return nil, err
 	}
@@ -419,7 +421,7 @@ func searchTree(vm *VM, mor types.ManagedObjectReference, name string) (*mo.Virt
 	case "VirtualMachine":
 		// Base recursive case, compare for value
 		vmMo := mo.VirtualMachine{}
-		err := vm.collector.RetrieveOne(vm.ctx, mor, []string{"name", "config", "guest.ipAddress", "guest.guestState", "guest.net", "runtime.question", "snapshot.currentSnapshot", "guest.toolsRunningStatus", "summary", "runtime"}, &vmMo)
+		err := vm.collector.RetrieveOne(vm.ctx, mor, []string{"name", "config", "datastore", "guest.ipAddress", "guest.guestState", "guest.net", "runtime.question", "snapshot.currentSnapshot", "guest.toolsRunningStatus", "summary", "runtime"}, &vmMo)
 		if err != nil {
 			return nil, NewErrorObjectNotFound(errors.New("could not find the vm"), name)
 		}
@@ -558,13 +560,20 @@ func removeExistingNetworks(vm *VM, vmObj *object.VirtualMachine) ([]types.BaseV
 }
 
 var cloneFromTemplate = func(vm *VM, dcMo *mo.Datacenter, usableDatastores []string) error {
-	n := util.Random(1, len(usableDatastores))
-	vm.datastore = usableDatastores[n-1]
-	dsMo, err := findDatastore(vm, dcMo, vm.datastore)
-	if err != nil {
-		return err
+	var (
+		err   error
+		dsMo  *mo.Datastore
+		dsMor types.ManagedObjectReference
+	)
+	if len(usableDatastores) != 0 {
+		n := util.Random(1, len(usableDatastores))
+		vm.datastore = usableDatastores[n-1]
+		dsMo, err = findDatastore(vm, dcMo, vm.datastore)
+		if err != nil {
+			return err
+		}
+		dsMor = dsMo.Reference()
 	}
-	dsMor := dsMo.Reference()
 	var template string
 	if vm.UseLocalTemplates {
 		template = createTemplateName(vm.Template, vm.datastore)
@@ -586,9 +595,21 @@ var cloneFromTemplate = func(vm *VM, dcMo *mo.Datacenter, usableDatastores []str
 	// to delete all the network cards and create VirtualDevice specs.
 	// For now only configure the datastore and the host.
 	relocateSpec := types.VirtualMachineRelocateSpec{
-		Pool:      &l.ResourcePool,
-		Host:      &l.Host,
-		Datastore: &dsMor,
+		Pool: &l.ResourcePool,
+	}
+
+	crMo, err := findClusterComputeResource(vm, dcMo, vm.Destination.DestinationName)
+	if err != nil {
+		return err
+	}
+
+	drsEnabled := *crMo.Configuration.DrsConfig.Enabled
+
+	if vm.Destination.HostSystem != "" || !drsEnabled {
+		relocateSpec.Host = &l.Host
+	}
+	if dsMo != nil {
+		relocateSpec.Datastore = &dsMor
 	}
 
 	deviceChangeSpec, err := reconfigureNetworks(vm, vmObj)
@@ -650,9 +671,13 @@ var cloneFromTemplate = func(vm *VM, dcMo *mo.Datacenter, usableDatastores []str
 	if vm.UseLinkedClones {
 		relocateSpec = types.VirtualMachineRelocateSpec{
 			Pool:         &l.ResourcePool,
-			Host:         &l.Host,
-			Datastore:    &dsMor,
 			DiskMoveType: "createNewChildDiskBacking",
+		}
+		if vm.Destination.HostSystem != "" {
+			relocateSpec.Host = &l.Host
+		}
+		if dsMo != nil {
+			relocateSpec.Datastore = &dsMor
 		}
 		cisp = types.VirtualMachineCloneSpec{
 			Location: relocateSpec,
@@ -739,6 +764,27 @@ func CreateDisk(l object.VirtualDeviceList, c types.BaseVirtualController, ds ty
 	return device
 }
 
+var getDatastoreForVm = func(vm *VM, vmMo *mo.VirtualMachine) ([]string,
+	error) {
+	var (
+		dsMos      []mo.Datastore
+		datastores []string
+		err        error
+	)
+	dsMors := vmMo.Datastore
+	err = vm.collector.Retrieve(vm.ctx, dsMors, []string{"info"}, &dsMos)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"Error retrieving datastores used by vm: %v",
+			err)
+	}
+	for _, dsMo := range dsMos {
+		datastores = append(datastores,
+			dsMo.Info.GetDatastoreInfo().Name)
+	}
+	return datastores, nil
+}
+
 // reconfigureVM :reconfigureVM adds the disks to the vm and returns the vmdk
 // file names of the disks added
 // root disk datastore is used by default
@@ -758,6 +804,15 @@ var reconfigureVM = func(vm *VM, vmMo *mo.VirtualMachine) ([]string, error) {
 	dcMo, err := GetDatacenter(vm)
 	if err != nil {
 		return nil, err
+	}
+
+	if vm.datastore == "" {
+		datastores, err := getDatastoreForVm(vm, vmMo)
+		if err != nil {
+			return nil, err
+		}
+		n := util.Random(1, len(datastores))
+		vm.datastore = datastores[n-1]
 	}
 
 	for _, disk := range vm.Disks {
@@ -1289,6 +1344,9 @@ func validateHost(vm *VM, hsMor types.ManagedObjectReference) (bool, error) {
 		}
 	}
 
+	if vm.datastore == "" {
+		return nwValid, nil
+	}
 	for _, ds := range hsMo.Datastore {
 		dsMo := mo.Datastore{}
 		err := vm.collector.RetrieveOne(vm.ctx, ds, []string{"name"}, &dsMo)

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -570,18 +570,17 @@ func (vm *VM) Provision() (err error) {
 	// Upload a template to all the datastores if `UseLocalTemplates` is set.
 	// Otherwise pick a random datastore out of the list that was passed in.
 	var datastores = vm.Datastores
-	if !vm.UseLocalTemplates {
+	if !vm.UseLocalTemplates && len(vm.Datastores) != 0 {
 		n := util.Random(1, len(vm.Datastores))
 		datastores = []string{vm.Datastores[n-1]}
 	}
 
+	var template string
+	template = vm.Template
 	usableDatastores := []string{}
 	for _, d := range datastores {
-		var template string
 		if vm.UseLocalTemplates {
 			template = createTemplateName(vm.Template, d)
-		} else {
-			template = vm.Template
 		}
 		// Does the VM template already exist?
 		e, err := Exists(vm, dcMo, template)

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -571,8 +571,7 @@ func (vm *VM) Provision() (err error) {
 	// Otherwise pick a random datastore out of the list that was passed in.
 	var datastores = vm.Datastores
 	if !vm.UseLocalTemplates && len(vm.Datastores) != 0 {
-		n := util.Random(1, len(vm.Datastores))
-		datastores = []string{vm.Datastores[n-1]}
+		datastores = []string{util.ChooseRandomString(vm.Datastores)}
 	}
 
 	var template string
@@ -660,8 +659,7 @@ func (vm *VM) AddDisk() ([]string, error) {
 	}
 
 	// Gets a random datastore from the list of datastores to create disk
-	n := util.Random(1, len(vm.Datastores))
-	vm.datastore = vm.Datastores[n-1]
+	vm.datastore = util.ChooseRandomString(vm.Datastores)
 
 	// Reconfigures vm with the new Disk
 	diskList, err := reconfigureVM(vm, vmMo)
@@ -1537,8 +1535,7 @@ func CreateTemplate(vm *VM) error {
 		return fmt.Errorf("%s : Template already exists", vm.Template)
 	}
 	//selects a datstore at random and uploads the template
-	n := util.Random(1, len(vm.Datastores))
-	vm.datastore = vm.Datastores[n-1]
+	vm.datastore = util.ChooseRandomString(vm.Datastores)
 	err = uploadTemplate(vm, dcMo, vm.datastore)
 	return err
 }


### PR DESCRIPTION
**Jira ID**

MRPHS-3566

**Problem**

Remove hostsystem and datastore from relocateSpec if hostsystem and datastore is empty. The hostsystem is selected on random basis if not passed. If Drs is enabled it should be selected via DRS.

**Solution**

Removed Host and datastore from relocate Spec if host or datastore is not specified in the request. The behaviour is as follows:

1) Host and datastore not specified and Cluster is Drs enabled -  Drs takes the responsibility to migrate the vm to appropriate host [ additional disks are added to the datastore passed with the disk config else the datastores associated with the vm ]
2) Host and datastore not specified and Cluster is not Drs enabled - libretto filters the hosts based on the network and datastore and create vm on that host
3) Host not specified, datastore is specified - the vm is migrated to the host to which the datastore is linked if any else gives error

**Unit Testing**

Done. Tried creating vm on drs enabled cluster (starling vcenter) with two hosts. Created 6 vms using c3ntry, all the vms are migrated to the host with less load. Logs are attached below:

[c3ntry.txt](https://github.com/apporbit/libretto/files/1461120/c3ntry.txt)

Tried vm creation with different scenarios. For example host not specified on drs enabled cluster and drs disabled cluster, datastore not specified with and without host. The vm is created successfully as specified in the behaviour above.