### PR TITLE
MRPHS-3602 : Empty Datastore list shown in cluster

### DIFF
--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -1099,11 +1099,13 @@ func DeleteTemplate(vm *VM) error {
 // GetDatastores : Returns the datastores in a host/cluster in a cluster
 func GetDatastores(vm *VM) ([]Datastore, error) {
 	var (
-		datastore     mo.Datastore
-		hsMo          mo.HostSystem
-		datastoreList []Datastore
-		dsMoList      []types.ManagedObjectReference
+		datastore mo.Datastore
+		hsMo      mo.HostSystem
+		dsMoList  []types.ManagedObjectReference
 	)
+
+	datastoreList := []Datastore{}
+
 	// set up session to vcenter server
 	if err := SetupSession(vm); err != nil {
 		return nil, err


### PR DESCRIPTION
 ### Symptom:
[\<JiraID>](https://apporbit.atlassian.net/browse/Mrphs 3602)

 

### Description:
While Editing Infra VM project settings datastore list empty shown
 
### Testing:

**Unit Testing:**
```
 [root@deepali-dev3 appos]# go run c3ntryrpc/example/c3ntry_client.go
Sending request:
action:"get_datastore_list" args:"{\"cloud_provider_id\":2,\"cloud_type\":\"vsphere\",\"Insecure\":true,\"Username\":\"developer@vsphere.local\",\"Password\":\"****\",\"Host\":\"209.205.216.11\",\"datacenter\":\"developer-lab\",\"Destination\":{\"DestinationType\":\"cluster\",\"DestinationName\":\"Cluster-2\",\"HostSystem\":\"\"}}"

2017/11/10 11:47:00 Received Response:
result:"[]" progress:100

2017/11/10 11:47:00 Response String:
{"result":"[]","progress":100}

2017/11/10 11:47:00 Breaking..


