### PR TITLE
MRPHS-3405: Extend AWS Support

### DIFF
--- a/virtualmachine/aws/util.go
+++ b/virtualmachine/aws/util.go
@@ -391,3 +391,37 @@ func GetVolumeInput(volume *EbsBlockVolume) *ec2.CreateVolumeInput {
 	}
 	return input
 }
+
+// GetVMAWSImage: returns local Image struct object for given ec2.Image
+func GetVMAWSImage(image *ec2.Image) Image {
+	ebsVolumes := make([]*EbsBlockVolume, 0)
+	for _, blockDeviceMapping := range image.BlockDeviceMappings {
+		ebsVolume := &EbsBlockVolume{
+			DeviceName: *blockDeviceMapping.DeviceName}
+		if blockDeviceMapping.Ebs != nil {
+			ebsVolume.VolumeSize = blockDeviceMapping.Ebs.VolumeSize
+			ebsVolume.VolumeType = *blockDeviceMapping.Ebs.VolumeType
+		}
+		ebsVolumes = append(ebsVolumes, ebsVolume)
+	}
+	img := Image{
+		Id:                 image.ImageId,
+		Name:               image.Name,
+		Description:        image.Description,
+		State:              image.State,
+		OwnerId:            image.OwnerId,
+		OwnerAlias:         image.ImageOwnerAlias,
+		CreationDate:       image.CreationDate,
+		Architecture:       image.Architecture,
+		Platform:           image.Platform,
+		Hypervisor:         image.Hypervisor,
+		VirtualizationType: image.VirtualizationType,
+		ImageType:          image.ImageType,
+		KernelId:           image.KernelId,
+		RootDeviceName:     image.RootDeviceName,
+		RootDeviceType:     image.RootDeviceType,
+		Public:             image.Public,
+		EbsVolumes:         ebsVolumes}
+
+	return img
+}

--- a/virtualmachine/aws/util.go
+++ b/virtualmachine/aws/util.go
@@ -311,8 +311,8 @@ func GetInstanceStatus(svc *ec2.EC2, instID string) (*InstanceStatus, error) {
 	return status, nil
 }
 
-// GetFilters: converts filter map to array of pointers to ec2.Filter objects
-func GetFilters(filterMap map[string][]*string) []*ec2.Filter {
+// getFilters: converts filter map to array of pointers to ec2.Filter objects
+func getFilters(filterMap map[string][]*string) []*ec2.Filter {
 	filters := make([]*ec2.Filter, 0)
 	for key, values := range filterMap {
 		filters = append(filters, &ec2.Filter{
@@ -322,9 +322,9 @@ func GetFilters(filterMap map[string][]*string) []*ec2.Filter {
 	return filters
 }
 
-// ToEc2IpPermissions: converts array of IpPermission objects to
+// toEc2IpPermissions: converts array of IpPermission objects to
 // array of pointer to ec2.IpPermission
-func ToEc2IpPermissions(ipPermissions []IpPermission) []*ec2.IpPermission {
+func toEc2IpPermissions(ipPermissions []IpPermission) []*ec2.IpPermission {
 	ec2IpPermissions := make([]*ec2.IpPermission, 0)
 	for _, ipPermission := range ipPermissions {
 		ec2IpPermission := &ec2.IpPermission{
@@ -352,9 +352,9 @@ func ToEc2IpPermissions(ipPermissions []IpPermission) []*ec2.IpPermission {
 	return ec2IpPermissions
 }
 
-// ToVMAWSIpPermissions: converts array of ec2.IpPermission to
+// toVMAWSIpPermissions: converts array of ec2.IpPermission to
 // array of local IpPermission struct object
-func ToVMAWSIpPermissions(ec2IpPermissions []*ec2.IpPermission) []IpPermission {
+func toVMAWSIpPermissions(ec2IpPermissions []*ec2.IpPermission) []IpPermission {
 	ipPermissions := make([]IpPermission, 0)
 	for _, ipPermission := range ec2IpPermissions {
 		ipv4ranges := make([]string, 0)
@@ -375,8 +375,8 @@ func ToVMAWSIpPermissions(ec2IpPermissions []*ec2.IpPermission) []IpPermission {
 	return ipPermissions
 }
 
-// GetVolumeInput: returns input for create volume operation
-func GetVolumeInput(volume *EbsBlockVolume) *ec2.CreateVolumeInput {
+// getVolumeInput: returns input for create volume operation
+func getVolumeInput(volume *EbsBlockVolume) *ec2.CreateVolumeInput {
 	if volume.VolumeSize == nil {
 		defaultSize := int64(defaultVolumeSize)
 		volume.VolumeSize = &defaultSize
@@ -392,8 +392,8 @@ func GetVolumeInput(volume *EbsBlockVolume) *ec2.CreateVolumeInput {
 	return input
 }
 
-// GetVMAWSImage: returns local Image struct object for given ec2.Image
-func GetVMAWSImage(image *ec2.Image) Image {
+// getVMAWSImage: returns local Image struct object for given ec2.Image
+func getVMAWSImage(image *ec2.Image) Image {
 	ebsVolumes := make([]*EbsBlockVolume, 0)
 	for _, blockDeviceMapping := range image.BlockDeviceMappings {
 		ebsVolume := &EbsBlockVolume{

--- a/virtualmachine/aws/util.go
+++ b/virtualmachine/aws/util.go
@@ -298,7 +298,8 @@ func GetInstanceStatus(svc *ec2.EC2, instID string) (*InstanceStatus, error) {
 	statusOutput, err := svc.DescribeInstanceStatus(input)
 
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get instance status: %v", err)
+		return nil, fmt.Errorf("Failed to get instance (instanceId %s) "+
+			"status: %v", instID, err)
 	}
 
 	instanceStatus := statusOutput.InstanceStatuses[0]

--- a/virtualmachine/aws/util.go
+++ b/virtualmachine/aws/util.go
@@ -191,14 +191,14 @@ func instanceInfo(vm *VM) *ec2.RunInstancesInput {
 	if len(vm.SecurityGroups) > 0 {
 		sgid = make([]*string, 0)
 		for _, sg := range vm.SecurityGroups {
-			sgid = append(sgid, aws.String(sg))
+			sgid = append(sgid, aws.String(sg.Id))
 		}
 	}
 
 	devices := make([]*ec2.BlockDeviceMapping, len(vm.Volumes))
 	for _, volume := range vm.Volumes {
-		if volume.VolumeSize == 0 {
-			volume.VolumeSize = defaultVolumeSize
+		if volume.VolumeSize == new(int64) {
+			volume.VolumeSize = aws.Int64(int64(defaultVolumeSize))
 		}
 		if volume.VolumeType == "" {
 			volume.VolumeType = defaultVolumeType
@@ -207,7 +207,7 @@ func instanceInfo(vm *VM) *ec2.RunInstancesInput {
 		devices = append(devices, &ec2.BlockDeviceMapping{
 			DeviceName: aws.String(volume.DeviceName),
 			Ebs: &ec2.EbsBlockDevice{
-				VolumeSize:          aws.Int64(int64(volume.VolumeSize)),
+				VolumeSize:          volume.VolumeSize,
 				VolumeType:          aws.String(volume.VolumeType),
 				DeleteOnTermination: aws.Bool(!vm.KeepRootVolumeOnDestroy),
 			},
@@ -287,4 +287,106 @@ func DeleteKeyPair(name string, region string) error {
 	}
 
 	return nil
+}
+
+// GetInstanceStatus: returns status of given instances
+// Status includes availabilityZone & state
+func GetInstanceStatus(svc *ec2.EC2, instID string) (*InstanceStatus, error) {
+	input := &ec2.DescribeInstanceStatusInput{
+		IncludeAllInstances: func(val bool) *bool { return &val }(true),
+		InstanceIds:         []*string{&instID}}
+	statusOutput, err := svc.DescribeInstanceStatus(input)
+
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get instance status: %v", err)
+	}
+
+	instanceStatus := statusOutput.InstanceStatuses[0]
+	status := &InstanceStatus{
+		AvailabilityZone: *instanceStatus.AvailabilityZone,
+		InstanceId:       *instanceStatus.InstanceId,
+		State:            *instanceStatus.InstanceState.Name}
+
+	return status, nil
+}
+
+// GetFilters: converts filter map to array of pointers to ec2.Filter objects
+func GetFilters(filterMap map[string][]*string) []*ec2.Filter {
+	filters := make([]*ec2.Filter, 0)
+	for key, values := range filterMap {
+		filters = append(filters, &ec2.Filter{
+			Name:   &key,
+			Values: values})
+	}
+	return filters
+}
+
+// ToEc2IpPermissions: converts array of IpPermission objects to
+// array of pointer to ec2.IpPermission
+func ToEc2IpPermissions(ipPermissions []IpPermission) []*ec2.IpPermission {
+	ec2IpPermissions := make([]*ec2.IpPermission, 0)
+	for _, ipPermission := range ipPermissions {
+		ec2IpPermission := &ec2.IpPermission{
+			FromPort:   ipPermission.FromPort,
+			ToPort:     ipPermission.ToPort,
+			IpProtocol: &ipPermission.IpProtocol}
+
+		if ipPermission.Ipv4Ranges != nil && len(ipPermission.Ipv4Ranges) > 0 {
+			ipRanges := make([]*ec2.IpRange, 0)
+			for _, ipv4Range := range ipPermission.Ipv4Ranges {
+				ipRanges = append(ipRanges, &ec2.IpRange{
+					CidrIp: &ipv4Range})
+			}
+			ec2IpPermission.IpRanges = ipRanges
+		} else {
+			ipv6Ranges := make([]*ec2.Ipv6Range, 0)
+			for _, ipv6Range := range ipPermission.Ipv6Ranges {
+				ipv6Ranges = append(ipv6Ranges, &ec2.Ipv6Range{
+					CidrIpv6: &ipv6Range})
+			}
+			ec2IpPermission.Ipv6Ranges = ipv6Ranges
+		}
+		ec2IpPermissions = append(ec2IpPermissions, ec2IpPermission)
+	}
+	return ec2IpPermissions
+}
+
+// ToVMAWSIpPermissions: converts array of ec2.IpPermission to
+// array of local IpPermission struct object
+func ToVMAWSIpPermissions(ec2IpPermissions []*ec2.IpPermission) []IpPermission {
+	ipPermissions := make([]IpPermission, 0)
+	for _, ipPermission := range ec2IpPermissions {
+		ipv4ranges := make([]string, 0)
+		for _, ipv4range := range ipPermission.IpRanges {
+			ipv4ranges = append(ipv4ranges, *ipv4range.CidrIp)
+		}
+		ipv6ranges := make([]string, 0)
+		for _, ipv6range := range ipPermission.Ipv6Ranges {
+			ipv6ranges = append(ipv6ranges, *ipv6range.CidrIpv6)
+		}
+		ipPermissions = append(ipPermissions, IpPermission{
+			FromPort:   ipPermission.FromPort,
+			ToPort:     ipPermission.ToPort,
+			IpProtocol: *ipPermission.IpProtocol,
+			Ipv4Ranges: ipv4ranges,
+			Ipv6Ranges: ipv6ranges})
+	}
+	return ipPermissions
+}
+
+// GetVolumeInput: returns input for create volume operation
+func GetVolumeInput(volume *EbsBlockVolume) *ec2.CreateVolumeInput {
+	if volume.VolumeSize == nil {
+		defaultSize := int64(defaultVolumeSize)
+		volume.VolumeSize = &defaultSize
+	}
+	if volume.VolumeType == "" {
+		volume.VolumeType = defaultVolumeType
+	}
+	input := &ec2.CreateVolumeInput{
+		AvailabilityZone: &volume.AvailabilityZone,
+		Size:             volume.VolumeSize,
+		VolumeType:       &volume.VolumeType,
+	}
+	return input
 }

--- a/virtualmachine/aws/vm.go
+++ b/virtualmachine/aws/vm.go
@@ -560,7 +560,7 @@ func (vm *VM) GetSubnetList(filter map[string][]*string) ([]Subnet, error) {
 		return nil, fmt.Errorf("Failed to get AWS service: %v", err)
 	}
 
-	filters := GetFilters(filter)
+	filters := getFilters(filter)
 
 	input := &ec2.DescribeSubnetsInput{
 		Filters: filters}
@@ -600,7 +600,7 @@ func (vm *VM) GetSecurityGroupList(filter map[string][]*string) ([]SecurityGroup
 		return nil, fmt.Errorf("Failed to get AWS service: %v", err)
 	}
 
-	filters := GetFilters(filter)
+	filters := getFilters(filter)
 
 	input := &ec2.DescribeSecurityGroupsInput{
 		Filters: filters}
@@ -612,8 +612,8 @@ func (vm *VM) GetSecurityGroupList(filter map[string][]*string) ([]SecurityGroup
 
 	response := make([]SecurityGroup, 0)
 	for _, securityGroup := range secGrpListOutput.SecurityGroups {
-		ipPermissionsEgress := ToVMAWSIpPermissions(securityGroup.IpPermissionsEgress)
-		ipPermissions := ToVMAWSIpPermissions(securityGroup.IpPermissions)
+		ipPermissionsEgress := toVMAWSIpPermissions(securityGroup.IpPermissionsEgress)
+		ipPermissions := toVMAWSIpPermissions(securityGroup.IpPermissions)
 
 		response = append(response, SecurityGroup{
 			Id:                  *securityGroup.GroupId,
@@ -635,7 +635,7 @@ func (vm *VM) GetImageList(filter map[string][]*string) ([]Image, error) {
 		return nil, fmt.Errorf("Failed to get AWS service: %v", err)
 	}
 
-	filters := GetFilters(filter)
+	filters := getFilters(filter)
 
 	input := &ec2.DescribeImagesInput{
 		Filters: filters}
@@ -647,7 +647,7 @@ func (vm *VM) GetImageList(filter map[string][]*string) ([]Image, error) {
 
 	response := make([]Image, 0)
 	for _, image := range imageListOutput.Images {
-		img := GetVMAWSImage(image)
+		img := getVMAWSImage(image)
 		response = append(response, img)
 	}
 	return response, nil
@@ -662,7 +662,7 @@ func (vm *VM) AuthorizeSecurityGroup() error {
 
 	secGrp := vm.SecurityGroups[0]
 
-	ec2IpPermissions := ToEc2IpPermissions(secGrp.IpPermissions)
+	ec2IpPermissions := toEc2IpPermissions(secGrp.IpPermissions)
 	input := &ec2.AuthorizeSecurityGroupIngressInput{
 		GroupId:       &secGrp.Id,
 		IpPermissions: ec2IpPermissions}
@@ -672,7 +672,7 @@ func (vm *VM) AuthorizeSecurityGroup() error {
 		return fmt.Errorf("Failed to authorize security group ingress rules: %v", err)
 	}
 
-	ec2IpPermissionsEgress := ToEc2IpPermissions(
+	ec2IpPermissionsEgress := toEc2IpPermissions(
 		secGrp.IpPermissionsEgress)
 	egressInput := &ec2.AuthorizeSecurityGroupEgressInput{
 		GroupId:       &secGrp.Id,
@@ -694,7 +694,7 @@ func (vm *VM) RevokeSecurityGroup() error {
 
 	secGrp := vm.SecurityGroups[0]
 
-	ec2IpPermissions := ToEc2IpPermissions(secGrp.IpPermissions)
+	ec2IpPermissions := toEc2IpPermissions(secGrp.IpPermissions)
 	input := &ec2.RevokeSecurityGroupIngressInput{
 		GroupId:       &secGrp.Id,
 		IpPermissions: ec2IpPermissions}
@@ -703,7 +703,7 @@ func (vm *VM) RevokeSecurityGroup() error {
 		return fmt.Errorf("Failed to revoke security group ingress rules: %v", err)
 	}
 
-	ec2IpPermissionsEgress := ToEc2IpPermissions(
+	ec2IpPermissionsEgress := toEc2IpPermissions(
 		secGrp.IpPermissionsEgress)
 	egressInput := &ec2.RevokeSecurityGroupEgressInput{
 		GroupId:       &secGrp.Id,
@@ -730,7 +730,7 @@ func (vm *VM) CreateVolume() error {
 	}
 	volume.AvailabilityZone = instanceStatus.AvailabilityZone
 
-	input := GetVolumeInput(&volume)
+	input := getVolumeInput(&volume)
 	response, err := svc.CreateVolume(input)
 	if err != nil {
 		return fmt.Errorf("Failed to create volume: %v", err)

--- a/virtualmachine/aws/vm.go
+++ b/virtualmachine/aws/vm.go
@@ -73,28 +73,104 @@ type VM struct {
 	Region                 string // required
 	AMI                    string
 	InstanceType           string
-	InstanceID             string
+	InstanceID             string // required when adding volume
 	KeyPair                string // required
 	IamInstanceProfileName string
 	PrivateIPAddress       string
 
-	Volumes                      []EBSVolume
+	// required when addding or deleting volume
+	Volumes                      []EbsBlockVolume
 	KeepRootVolumeOnDestroy      bool
 	DeleteNonRootVolumeOnDestroy bool
 
-	VPC            string
-	Subnet         string
-	SecurityGroups []string
+	VPC    string
+	Subnet string
+	// required when modifying security group rules
+	// all other parameters except this one and Region
+	// is ingnored while security group modification
+	SecurityGroups []SecurityGroup
 
 	SSHCreds            ssh.Credentials // required
 	DeleteKeysOnDestroy bool
 }
 
-// EBSVolume represents an EBS Volume
-type EBSVolume struct {
-	DeviceName string
-	VolumeSize int
-	VolumeType string
+// Region represents a AWS Region
+type Region struct {
+	Name           string `json:"name,omitempty"`
+	RegionEndpoint string `json:"region_endpoint,omitempty"`
+}
+
+// Zone represents a AWS availability zone
+type Zone struct {
+	Name   string `json:"name,omitempty"`
+	State  string `json:"state,omitempty"`
+	Region string `json:"region,omitempty"`
+}
+
+// VPC represents a AWS VPC
+type VPC struct {
+	Id         string   `json:"id,omitempty"`
+	State      string   `json:"state,omitempty"`
+	IsDefault  *bool    `json:"is_default,omitempty"`
+	IPv4Blocks []string `json:"ipv4_blocks,omitempty"`
+	IPv6Blocks []string `json:"ipv6_blocks,omitempty"`
+	// ID of DHCP options associated with VPC
+	DhcpOptionsId string `json:"dhcp_options_id,omitempty"`
+	// Allowed tenancy of instances launched into the VPC
+	InstanceTenancy string `json:"instance_tenancy,omitempty"`
+}
+
+// Subnet represents a AWS Subnet
+type Subnet struct {
+	Id                    string   `json:"id,omitempty"`
+	State                 string   `json:"state,omitempty"`
+	VpcId                 string   `json:"vpc_id,omitempty"`
+	IPv4Block             string   `json:"ipv4block,omitempty"`
+	IPv6Blocks            []string `json:"ipv6blocks,omitempty"`
+	AvailableAddressCount *int64   `json:"available_address_count,omitempty"`
+	// Availability Zone of the subnet
+	AvailabilityZone string `json:"availability_zone,omitempty"`
+	// Indicates if this is default for Availability Zone
+	DefaultForAz        bool `json:"default_for_az,omitempty"`
+	MapPublicIpOnLaunch bool `json:"map_public_ip_on_launch,omitempty"`
+}
+
+// IpPermission in AWS is used to represent inbound or outbound rules
+// associated with SecurityGroup
+type IpPermission struct {
+	FromPort   *int64   `json:"from_port,omitempty"`
+	ToPort     *int64   `json:"to_port,omitempty"`
+	IpProtocol string   `json:"ip_protocol,omitempty"`
+	Ipv4Ranges []string `json:"ipv4_ranges,omitempty"`
+	Ipv6Ranges []string `json:"ipv6_ranges,omitempty"`
+}
+
+// SecurityGroup represents a AWS SecurityGroup
+type SecurityGroup struct {
+	Id                  string         `json:"id,omitempty"`
+	Name                string         `json:"name,omitempty"`
+	Description         string         `json:"description,omitempty"`
+	OwnerId             string         `json:"owner_id,omitempty"`
+	VpcId               string         `json:"vpc_id,omitempty"`
+	IpPermissionsEgress []IpPermission `json:"ip_permissions_egress,omitempty"`
+	IpPermissions       []IpPermission `json:"ip_permissions,omitempty"`
+}
+
+// InstanceStatus represents AWS InstanceStatus
+type InstanceStatus struct {
+	AvailabilityZone string `json:"availability_zone,omitempty"`
+	InstanceId       string `json:"instance_id,omitempty"`
+	State            string `json:"state,omitempty"`
+}
+
+// EbsBlockVolume represents a AWS EbsBlockDevice
+type EbsBlockVolume struct {
+	DeviceName       string `json:"device_name,omitempty"`
+	VolumeSize       *int64 `json:"volume_size,omitempty"`
+	VolumeType       string `json:"volume_type,omitempty"`
+	AvailabilityZone string `json:"availability_zone,omitempty"`
+	VolumeId         string `json:"volume_id,omitempty"`
+	SnapshotId       string `json:"snapshot_id,omitempty"`
 }
 
 // GetName returns the name of the virtual machine
@@ -249,6 +325,10 @@ func (vm *VM) Destroy() error {
 		return err
 	}
 
+	if err := waitUntilTerminated(svc, vm.InstanceID); err != nil {
+		return err
+	}
+
 	if !vm.DeleteKeysOnDestroy {
 		return nil
 	}
@@ -333,6 +413,10 @@ func (vm *VM) Halt() error {
 		return fmt.Errorf("Failed to stop instance: %v", err)
 	}
 
+	if err := waitUntilStopped(svc, vm.InstanceID); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -356,6 +440,321 @@ func (vm *VM) Start() error {
 	})
 	if err != nil {
 		return fmt.Errorf("Failed to start instance: %v", err)
+	}
+
+	if err := waitUntilRunning(svc, vm.InstanceID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetRegionList: returns list of regions
+func (vm *VM) GetRegionList() ([]Region, error) {
+	svc, err := getService(vm.Region)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get AWS service: %v", err)
+	}
+
+	regionListOutput, err := svc.DescribeRegions(&ec2.DescribeRegionsInput{})
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get region list: %v", err)
+	}
+	response := make([]Region, 0)
+	for _, region := range regionListOutput.Regions {
+		response = append(response, Region{
+			Name:           *region.RegionName,
+			RegionEndpoint: *region.Endpoint})
+	}
+
+	return response, nil
+}
+
+// GetAvailabilityZoneList: returns list of availability zones for a region
+func (vm *VM) GetAvailabilityZoneList() ([]Zone, error) {
+	svc, err := getService(vm.Region)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get AWS service: %v", err)
+	}
+
+	zoneListOutput, err := svc.DescribeAvailabilityZones(
+		&ec2.DescribeAvailabilityZonesInput{})
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get availabilityZone list: %v", err)
+	}
+	response := make([]Zone, 0)
+	for _, zone := range zoneListOutput.AvailabilityZones {
+		response = append(response, Zone{
+			Name:   *zone.ZoneName,
+			State:  *zone.State,
+			Region: *zone.RegionName})
+	}
+	return response, nil
+}
+
+// GetVPCList: returns list of VPCs for given region
+func (vm *VM) GetVPCList() ([]VPC, error) {
+	svc, err := getService(vm.Region)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get AWS service: %v", err)
+	}
+
+	vpcListOutput, err := svc.DescribeVpcs(&ec2.DescribeVpcsInput{})
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get VPC list: %v", err)
+	}
+	response := make([]VPC, 0)
+	for _, vpc := range vpcListOutput.Vpcs {
+		ipv4Blocks := make([]string, 0)
+		for _, ipv4Block := range vpc.CidrBlockAssociationSet {
+			ipv4Blocks = append(ipv4Blocks,
+				*ipv4Block.CidrBlock)
+		}
+
+		ipv6Blocks := make([]string, 0)
+		for _, ipv6Block := range vpc.Ipv6CidrBlockAssociationSet {
+			ipv6Blocks = append(ipv6Blocks,
+				*ipv6Block.Ipv6CidrBlock)
+		}
+
+		response = append(response, VPC{
+			Id:              *vpc.VpcId,
+			State:           *vpc.State,
+			IsDefault:       vpc.IsDefault,
+			DhcpOptionsId:   *vpc.DhcpOptionsId,
+			InstanceTenancy: *vpc.InstanceTenancy,
+			IPv4Blocks:      ipv4Blocks,
+			IPv6Blocks:      ipv6Blocks})
+	}
+	return response, nil
+}
+
+// GetSubnetList: returns list of all subnet for given region
+// most relevant filter(s) (map-keys): "vpc-id", "subnet-id", "availabilityZone"
+// See all available filters at below link
+// http://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#DescribeSubnetsInput
+func (vm *VM) GetSubnetList(filter map[string][]*string) ([]Subnet, error) {
+	svc, err := getService(vm.Region)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get AWS service: %v", err)
+	}
+
+	filters := GetFilters(filter)
+
+	input := &ec2.DescribeSubnetsInput{
+		Filters: filters}
+	subnetListOutput, err := svc.DescribeSubnets(input)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get Subnet list: %v", err)
+	}
+	response := make([]Subnet, 0)
+	for _, subnet := range subnetListOutput.Subnets {
+		ipv6Blocks := make([]string, 0)
+		for _, ipv6Block := range subnet.Ipv6CidrBlockAssociationSet {
+			ipv6Blocks = append(ipv6Blocks,
+				*ipv6Block.Ipv6CidrBlock)
+		}
+
+		response = append(response, Subnet{
+			Id:                    *subnet.SubnetId,
+			State:                 *subnet.State,
+			VpcId:                 *subnet.VpcId,
+			IPv4Block:             *subnet.CidrBlock,
+			AvailableAddressCount: subnet.AvailableIpAddressCount,
+			AvailabilityZone:      *subnet.AvailabilityZone,
+			DefaultForAz:          *subnet.DefaultForAz,
+			MapPublicIpOnLaunch:   *subnet.MapPublicIpOnLaunch,
+			IPv6Blocks:            ipv6Blocks})
+	}
+	return response, nil
+}
+
+// GetSecurityGroupList : returns list of all securityGroup for given region
+// most relevant filter(s) (map-keys): "vpc-id", "group-id"
+// See all available filters at below link
+// http://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#DescribeSecurityGroupsInput
+func (vm *VM) GetSecurityGroupList(filter map[string][]*string) ([]SecurityGroup, error) {
+	svc, err := getService(vm.Region)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get AWS service: %v", err)
+	}
+
+	filters := GetFilters(filter)
+
+	input := &ec2.DescribeSecurityGroupsInput{
+		Filters: filters}
+
+	secGrpListOutput, err := svc.DescribeSecurityGroups(input)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get SecurityGroup list: %v", err)
+	}
+
+	response := make([]SecurityGroup, 0)
+	for _, securityGroup := range secGrpListOutput.SecurityGroups {
+		ipPermissionsEgress := ToVMAWSIpPermissions(securityGroup.IpPermissionsEgress)
+		ipPermissions := ToVMAWSIpPermissions(securityGroup.IpPermissions)
+
+		response = append(response, SecurityGroup{
+			Id:                  *securityGroup.GroupId,
+			Name:                *securityGroup.GroupName,
+			Description:         *securityGroup.Description,
+			OwnerId:             *securityGroup.OwnerId,
+			VpcId:               *securityGroup.VpcId,
+			IpPermissionsEgress: ipPermissionsEgress,
+			IpPermissions:       ipPermissions})
+	}
+	return response, nil
+}
+
+// AuthorizeSecurityGroup: Adds one or more rules to a security group
+func (vm *VM) AuthorizeSecurityGroup() error {
+	svc, err := getService(vm.Region)
+	if err != nil {
+		return fmt.Errorf("Failed to get AWS service: %v", err)
+	}
+
+	secGrp := vm.SecurityGroups[0]
+
+	ec2IpPermissions := ToEc2IpPermissions(secGrp.IpPermissions)
+	input := &ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId:       &secGrp.Id,
+		IpPermissions: ec2IpPermissions}
+
+	_, err = svc.AuthorizeSecurityGroupIngress(input)
+	if err != nil {
+		return fmt.Errorf("Failed to authorize security group ingress rules: %v", err)
+	}
+
+	ec2IpPermissionsEgress := ToEc2IpPermissions(
+		secGrp.IpPermissionsEgress)
+	egressInput := &ec2.AuthorizeSecurityGroupEgressInput{
+		GroupId:       &secGrp.Id,
+		IpPermissions: ec2IpPermissionsEgress}
+	_, err = svc.AuthorizeSecurityGroupEgress(egressInput)
+	if err != nil {
+		return fmt.Errorf("Failed to authorize security group egress rules: %v", err)
+	}
+
+	return nil
+}
+
+// RevokeSecurityGroup: Removes one or more rules from a security group
+func (vm *VM) RevokeSecurityGroup() error {
+	svc, err := getService(vm.Region)
+	if err != nil {
+		return fmt.Errorf("Failed to get AWS service: %v", err)
+	}
+
+	secGrp := vm.SecurityGroups[0]
+
+	ec2IpPermissions := ToEc2IpPermissions(secGrp.IpPermissions)
+	input := &ec2.RevokeSecurityGroupIngressInput{
+		GroupId:       &secGrp.Id,
+		IpPermissions: ec2IpPermissions}
+	_, err = svc.RevokeSecurityGroupIngress(input)
+	if err != nil {
+		return fmt.Errorf("Failed to revoke security group ingress rules: %v", err)
+	}
+
+	ec2IpPermissionsEgress := ToEc2IpPermissions(
+		secGrp.IpPermissionsEgress)
+	egressInput := &ec2.RevokeSecurityGroupEgressInput{
+		GroupId:       &secGrp.Id,
+		IpPermissions: ec2IpPermissionsEgress}
+	_, err = svc.RevokeSecurityGroupEgress(egressInput)
+	if err != nil {
+		return fmt.Errorf("Failed to revoke security group egress rules: %v", err)
+	}
+
+	return nil
+}
+
+// CreateVolume: Creates a volume with given parameter
+func (vm *VM) CreateVolume() error {
+	svc, err := getService(vm.Region)
+	if err != nil {
+		return fmt.Errorf("Failed to get AWS service: %v", err)
+	}
+
+	volume := vm.Volumes[0]
+	instanceStatus, err := GetInstanceStatus(svc, vm.InstanceID)
+	if err != nil {
+		return fmt.Errorf("Failed to get availability zone of instance: %v", err)
+	}
+	volume.AvailabilityZone = instanceStatus.AvailabilityZone
+
+	input := GetVolumeInput(&volume)
+	response, err := svc.CreateVolume(input)
+	if err != nil {
+		return fmt.Errorf("Failed to create volume: %v", err)
+	}
+
+	if err := waitUntilVolumeReady(svc, *response.VolumeId); err != nil {
+		return err
+	}
+
+	volume.VolumeId = *response.VolumeId
+	vm.Volumes[0] = volume
+
+	return nil
+}
+
+// AttachVolume: Attaches given volume to given instance
+func (vm *VM) AttachVolume() error {
+	svc, err := getService(vm.Region)
+	if err != nil {
+		return fmt.Errorf("Failed to get AWS service: %v", err)
+	}
+
+	volume := vm.Volumes[0]
+	input := &ec2.AttachVolumeInput{
+		Device:     &volume.DeviceName,
+		InstanceId: &vm.InstanceID,
+		VolumeId:   &volume.VolumeId}
+	_, err = svc.AttachVolume(input)
+	if err != nil {
+		return fmt.Errorf("Failed to attach volume: %v", err)
+	}
+
+	return nil
+}
+
+// DetachVolume: Detaches volume with given Id from instance
+func (vm *VM) DetachVolume() error {
+	svc, err := getService(vm.Region)
+	if err != nil {
+		return fmt.Errorf("Failed to get AWS service: %v", err)
+	}
+
+	volume := vm.Volumes[0]
+	input := &ec2.DetachVolumeInput{
+		VolumeId: &volume.VolumeId}
+	_, err = svc.DetachVolume(input)
+	if err != nil {
+		return fmt.Errorf("Failed to detach volume: %v", err)
+	}
+
+	if err := waitUntilVolumeReady(svc, volume.VolumeId); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteVolume: Deletes volume with given Id
+// Disk must not be in-use by any instance
+func (vm *VM) DeleteVolume() error {
+	svc, err := getService(vm.Region)
+	if err != nil {
+		return fmt.Errorf("Failed to get AWS service: %v", err)
+	}
+
+	volume := vm.Volumes[0]
+	input := &ec2.DeleteVolumeInput{
+		VolumeId: &volume.VolumeId}
+	_, err = svc.DeleteVolume(input)
+	if err != nil {
+		return fmt.Errorf("Failed to delete volume: %v", err)
 	}
 
 	return nil

--- a/virtualmachine/aws/wait.go
+++ b/virtualmachine/aws/wait.go
@@ -198,6 +198,7 @@ func waitUntilState(svc *ec2.EC2, instanceID string,
 	for state, val := range matchBreakState {
 		if val {
 			matchState = state
+			break
 		}
 	}
 


### PR DESCRIPTION
**JIRA Id**
[MRPHS-3405](https://apporbit.atlassian.net/browse/MRPHS-3405)

**Problem**
Libretto does not support for getting Regions, AvailabilityZones, VPCs, Subnets, SecurityGroups, and for adding and removing rules to SecurityGroup & Volumes to VM.

**Solution** 
Support has been extended by implementing all these functions, which are also listed below. For various get calls (region, zone, etc.) new structures have been created and list of these structs returned for those calls.
For adding and revoking rules to SecurityGroup & adding and deleting volumes to VM, VM struct has been modified to include list of local structs created for SecurityGroup and Volume.
Also, wait functions have been implemented for Start, Halt & Destroy operations, which only returns when state of VM becomes stable.
- GetRegionList
- GetAvailabilityZoneList
- GetVPCList
- GetSubnetList
- GetSecurityGroupList
- GetImageList
- AuthorizeSecurityGroup
- RevokeSecurityGroup
- CreateVolume
- AttachVolume
- DetachVolume
- DeleteVolume  

**Testing**
Unit tested all these calls with client implemented in Halo. Logs attached.
[c3.log](https://github.com/apporbit/libretto/files/1465947/c3.log)
