### PR TITLE
Fixed get_template_vm_list for distributed virtual port group

### DIFF
--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -471,11 +470,6 @@ type VirtualEthernetCard struct {
 	NetworkName string `json:"network_name"`
 	MacAddress  string `json:"mac_address"`
 	NicName     string `json:"nic_name"`
-	// for distributed virtual port group
-	PortgroupKey      string `json:"port_group_key"`
-	SwitchUuid        string `json:"switch_uuid"`
-	OpaqueNetworkId   string `json:opaque_network_id""`
-	OpaqueNetworkType string `json:"opaque_network_type"`
 }
 
 type VMInfo struct {
@@ -744,12 +738,8 @@ func getNicInfo(vmMo mo.VirtualMachine) []VirtualEthernetCard {
 			switch b := nwcard.Backing.(type) {
 			case *types.VirtualEthernetCardNetworkBackingInfo:
 				nic.NetworkName = b.DeviceName
-			case *types.VirtualEthernetCardDistributedVirtualPortBackingInfo:
-				nic.SwitchUuid = b.Port.SwitchUuid
-				nic.PortgroupKey = b.Port.PortgroupKey
-			case *types.VirtualEthernetCardOpaqueNetworkBackingInfo:
-				nic.OpaqueNetworkId = b.OpaqueNetworkId
-				nic.OpaqueNetworkType = b.OpaqueNetworkType
+			default:
+				continue
 			}
 			nicInfo = append(nicInfo, nic)
 		}


### PR DESCRIPTION
### Symptom:

Fetching the nic info during get template vm list call failed.

### Description:

Get Template vm list call failed while fetching nic info as the distributed port group was attached to the template's nic which was not handled.

### Resolution:

Handled the different types of networks for while fetching nic info. The network types checked are Opaque network, Distributed port group and network types.

### Testing:

**Unit Testing:**

Done. Created new app templated, fetched the template info with port group and deployed vm apps with and without disks. The vm is deployed successfully.

[c3ntry.txt](https://github.com/apporbit/libretto/files/1491739/c3ntry.txt)


**Automated testing:**

NR

### Notes for reviewing:

<Order for reviewing>
<Other related PRs>
<Reason for smoke failure or smoke not done>
