### PR TITLE
MRPHS-3892 :  Network gets disconnected if the network type is distributed port group

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -518,12 +518,12 @@ func reconfigureNetworks(vm *VM, vmObj *object.VirtualMachine) ([]types.BaseVirt
 				var backing types.BaseVirtualDeviceBackingInfo
 				switch nwMappingObj.Network.Type {
 				case "Network":
-					nwObj := object.NewNetwork(
-						vm.client.Client,
-						nwMappingObj.Network)
-					backing, err =
-						nwObj.EthernetCardBackingInfo(
-							vm.ctx)
+					backing = &types.VirtualEthernetCardNetworkBackingInfo{
+						VirtualDeviceDeviceBackingInfo: types.VirtualDeviceDeviceBackingInfo{
+							DeviceName: nwMappingObj.Name,
+						},
+						Network: &nwMappingObj.Network,
+					}
 				case "DistributedVirtualPortgroup":
 					dvsObj := object.NewDistributedVirtualPortgroup(
 						vm.client.Client,
@@ -531,11 +531,10 @@ func reconfigureNetworks(vm *VM, vmObj *object.VirtualMachine) ([]types.BaseVirt
 					backing, err =
 						dvsObj.EthernetCardBackingInfo(
 							vm.ctx)
-				}
-				if err != nil {
-					return nil, fmt.Errorf(
-						"error fetching ethernet card "+
+					if err != nil {
+						return nil, fmt.Errorf("error fetching ethernet card "+
 							"backing info: %v", err)
+					}
 				}
 				device.GetVirtualDevice().Backing = backing
 				spec := &types.VirtualDeviceConfigSpec{

--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -512,20 +512,38 @@ func reconfigureNetworks(vm *VM, vmObj *object.VirtualMachine) ([]types.BaseVirt
 			// Edit device
 			nw = vm.Networks[idx]
 			for _, nwMappingObj := range networkMapping {
-				if nwMappingObj.Name == nw["name"] {
-					device.GetVirtualDevice().Backing = &types.VirtualEthernetCardNetworkBackingInfo{
-						VirtualDeviceDeviceBackingInfo: types.VirtualDeviceDeviceBackingInfo{
-							DeviceName: nwMappingObj.Name,
-						},
-						Network: &nwMappingObj.Network,
-					}
-					spec := &types.VirtualDeviceConfigSpec{
-						Operation: types.VirtualDeviceConfigSpecOperationEdit,
-						Device:    device,
-					}
-					deviceSpecs = append(deviceSpecs, spec)
-					break
+				if nwMappingObj.Name != nw["name"] {
+					continue
 				}
+				var backing types.BaseVirtualDeviceBackingInfo
+				switch nwMappingObj.Network.Type {
+				case "Network":
+					nwObj := object.NewNetwork(
+						vm.client.Client,
+						nwMappingObj.Network)
+					backing, err =
+						nwObj.EthernetCardBackingInfo(
+							vm.ctx)
+				case "DistributedVirtualPortgroup":
+					dvsObj := object.NewDistributedVirtualPortgroup(
+						vm.client.Client,
+						nwMappingObj.Network)
+					backing, err =
+						dvsObj.EthernetCardBackingInfo(
+							vm.ctx)
+				}
+				if err != nil {
+					return nil, fmt.Errorf(
+						"error fetching ethernet card "+
+							"backing info: %v", err)
+				}
+				device.GetVirtualDevice().Backing = backing
+				spec := &types.VirtualDeviceConfigSpec{
+					Operation: types.VirtualDeviceConfigSpecOperationEdit,
+					Device:    device,
+				}
+				deviceSpecs = append(deviceSpecs, spec)
+				break
 			}
 			idx++
 		}


### PR DESCRIPTION
**Jira-id**

MRPHS-3892

**Problem**

Network gets disconnected if the network type is distributed port group. Ethernet card backing type for distributed port group is set invalid due to which vcenter gives error when trying to connect to the network

**Resolution**

Set the correct backing type for distributed port group and network.

**Unit Testing**

Done. Tried creating vm with distributed port group. the Vm is created successfully and the port group is in connected state. Tried shut down and start operation on vm. The port group is set to connected again and the ip is assigned to the vm.

Logs attached below:

[c3ntry.txt](https://github.com/apporbit/libretto/files/1495417/c3ntry.txt)
[c3ntry1.txt](https://github.com/apporbit/libretto/files/1495418/c3ntry1.txt)
