### PR TITLE
MRPHS-3895 : need to recurse for all the folders while browsing all the app template

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -411,10 +411,11 @@ var findVM = func(vm *VM, dc *mo.Datacenter, name string) (*mo.VirtualMachine, e
 func splitPathToList(path string) []string {
 	pathList := make([]string, 0)
 
-	// split at escaped '/', if none length of returned slice will be 1
+	// split at escaped '/'
+	// if no escaped '/' are present length of returned slice will be 1
 	slashInName := strings.SplitN(path, "\\/", 2)
 
-	// split at '/' (path separatore) and append to pathList to return
+	// split at '/' (path separator) and append to pathList to return
 	pathList = append(pathList, strings.Split(slashInName[0], "/")...)
 
 	// if there are no escaped '/'

--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -393,7 +393,7 @@ var createRequest = func(r io.Reader, method string, insecure bool, length int64
 
 // findVM finds the vm Managed Object referenced by the name or returns an error if it is not found.
 var findVM = func(vm *VM, dc *mo.Datacenter, name string) (*mo.VirtualMachine, error) {
-	moVM, err := searchTree(vm, dc.VmFolder, name)
+	moVM, err := searchTree(vm, &dc.VmFolder, name)
 	if err != nil {
 		return moVM, err
 	}
@@ -404,43 +404,75 @@ var findVM = func(vm *VM, dc *mo.Datacenter, name string) (*mo.VirtualMachine, e
 	return moVM, vm.answerQuestion(moVM)
 }
 
-func searchTree(vm *VM, mor types.ManagedObjectReference, name string) (*mo.VirtualMachine, error) {
-	switch mor.Type {
-	case "Folder":
+func searchTree(vm *VM, mor *types.ManagedObjectReference, name string) (
+	*mo.VirtualMachine, error) {
+	var (
+		ref types.ManagedObjectReference
+	)
+
+	splitPath := strings.SplitN(name, "/", 2)
+
+	for mor != nil {
 		// Fetch the childEntity property of the folder and check them
 		folderMo := mo.Folder{}
-		err := vm.collector.RetrieveOne(vm.ctx, mor, []string{"childEntity"}, &folderMo)
+		err := vm.collector.RetrieveOne(vm.ctx, *mor, []string{
+			"childEntity"}, &folderMo)
 		if err != nil {
 			return nil, err
 		}
+
+		mor = nil
 		for _, child := range folderMo.ChildEntity {
-			m, e := searchTree(vm, child, name)
-			if e != nil {
-				if _, ok := e.(ErrorObjectNotFound); !ok {
-					return nil, e
+			switch child.Type {
+			case "Folder":
+				if len(splitPath) == 1 {
+					continue
+				}
+				childMo := mo.Folder{}
+				err = vm.collector.RetrieveOne(vm.ctx, child,
+					[]string{"name"}, &childMo)
+				if err != nil {
+					return nil, err
+				}
+
+				if childMo.Name == splitPath[0] {
+					splitPath = strings.SplitN(splitPath[1],
+						"/", 2)
+					ref = child
+					mor = &ref
+					break
+				}
+			case "VirtualMachine":
+				if len(splitPath) == 2 {
+					continue
+				}
+				// Base recursive case, compare for value
+				vmMo := mo.VirtualMachine{}
+				err := vm.collector.RetrieveOne(vm.ctx, child,
+					[]string{"name", "config", "datastore",
+						"guest",
+						"snapshot.currentSnapshot",
+						"summary", "runtime"}, &vmMo)
+				if err != nil {
+					return nil, NewErrorObjectNotFound(
+						errors.New(
+							"could not find vm"),
+						name)
+				}
+				if vmMo.Name == splitPath[0] {
+					return &vmMo, nil
 				}
 			}
-			if m != nil {
-				return m, nil
-			}
 		}
-	case "VirtualMachine":
-		// Base recursive case, compare for value
-		vmMo := mo.VirtualMachine{}
-		err := vm.collector.RetrieveOne(vm.ctx, mor, []string{"name",
-			"config", "datastore", "guest.ipAddress",
-			"guest.guestState", "guest.net", "runtime.question",
-			"snapshot.currentSnapshot", "guest.toolsRunningStatus",
-			"summary", "runtime"}, &vmMo)
-		if err != nil {
-			return nil, NewErrorObjectNotFound(errors.New("could not find the vm"), name)
+
+		if mor == nil {
+			return nil, NewErrorObjectNotFound(errors.New(
+				"could not find the vm"), name)
 		}
-		if vmMo.Name == name {
-			return &vmMo, nil
-		}
-		return nil, NewErrorObjectNotFound(errors.New("could not find the vm"), name)
 	}
-	return nil, NewErrorObjectNotFound(errors.New("could not find the vm"), name)
+
+	return nil, NewErrorObjectNotFound(errors.New("could not find the vm"),
+		name)
 }
 
 func getEthernetBacking(vm *VM, nwMor types.ManagedObjectReference,

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -1404,27 +1404,62 @@ func GetDcImageList(vm *VM) (map[string][]string, error) {
 }
 
 // getDcVMList : returns list of VirtualMachine objects in a Datacenter
-func getDcVMList(vm *VM, datacenter *object.Datacenter) ([]mo.VirtualMachine, error) {
-	var allVmsMo []mo.VirtualMachine
-
+func getDcVMList(vm *VM, datacenter *object.Datacenter) (
+	map[string]mo.VirtualMachine, error) {
 	// Set datacenter
 	vm.finder.SetDatacenter(datacenter)
-	// find the virtual machines in selected datacenter
-	allVms, err := vm.finder.VirtualMachineList(vm.ctx, "*")
+	folders, err := datacenter.Folders(vm.ctx)
 	if err != nil {
-		switch err.(type) {
-		case *find.NotFoundError:
-			return allVmsMo, nil
-		}
 		return nil, err
 	}
-	var vmsMor []types.ManagedObjectReference
-	for _, vm := range allVms {
-		vmsMor = append(vmsMor, vm.Reference())
+	return getVmsInFolder(vm, folders.VmFolder, "")
+}
+
+// getVmsInFolder: returns map of full path and mo.Virtualmachine struct of vms
+// in a vcenter folder
+func getVmsInFolder(vm *VM, folder *object.Folder, path string) (
+	map[string]mo.VirtualMachine, error) {
+	var (
+		allVms map[string]mo.VirtualMachine
+	)
+	allVms = make(map[string]mo.VirtualMachine)
+	children, err := folder.Children(vm.ctx)
+	if err != nil {
+		return nil, err
 	}
-	// get the vm names and config
-	err = vm.collector.Retrieve(vm.ctx, vmsMor, []string{"name", "config", "summary"}, &allVmsMo)
-	return allVmsMo, err
+	for _, entity := range children {
+		mor := entity.Reference()
+		switch mor.Type {
+		case "Folder":
+			// Fetch the childEntity property of the folder
+			folderMo := mo.Folder{}
+			err := vm.collector.RetrieveOne(vm.ctx, mor, []string{
+				"name"}, &folderMo)
+			if err != nil {
+				return nil, err
+			}
+			folder := object.NewFolder(vm.client.Client,
+				mor)
+			vms, err := getVmsInFolder(vm, folder,
+				path+folderMo.Name+"/")
+			if err != nil {
+				return nil, err
+			}
+			for k, v := range vms {
+				allVms[k] = v
+			}
+		case "VirtualMachine":
+			vmMo := mo.VirtualMachine{}
+			err := vm.collector.RetrieveOne(vm.ctx, mor, []string{
+				"name", "config", "runtime", "summary"}, &vmMo)
+			if err != nil {
+				return nil, err
+			}
+			vmName := path + vmMo.Name
+			allVms[vmName] = vmMo
+		}
+	}
+	return allVms, nil
 }
 
 // GetDcClusterList : GetDcClusterList returns the clusters in the datacenter
@@ -1461,7 +1496,9 @@ func GetDcClusterList(vm *VM) ([]ClusterComputeResource, error) {
 	}
 	// get the cluster names
 	var allClustersMo []mo.ClusterComputeResource
-	err = vm.collector.Retrieve(vm.ctx, clustersMor, []string{"name", "summary", "configuration", "host", "datastore", "network"}, &allClustersMo)
+	err = vm.collector.Retrieve(vm.ctx, clustersMor, []string{"name",
+		"summary", "configuration", "host", "datastore", "network"},
+		&allClustersMo)
 	if err != nil {
 		return nil, err
 	}
@@ -1542,7 +1579,8 @@ func GetHostList(vm *VM) ([]HostSystem, error) {
 		return nil, err
 	}
 	// find the Destination cluster
-	crMo, err := findClusterComputeResource(vm, dcMo, vm.Destination.DestinationName)
+	crMo, err := findClusterComputeResource(vm, dcMo,
+		vm.Destination.DestinationName)
 	if err != nil {
 		return nil, err
 	}
@@ -1551,7 +1589,8 @@ func GetHostList(vm *VM) ([]HostSystem, error) {
 	}
 	// get the host list in datacenter vm.Datacenter
 	for _, host := range crMo.Host {
-		err := vm.collector.RetrieveOne(vm.ctx, host, []string{"name", "summary", "runtime"}, &hsMo)
+		err := vm.collector.RetrieveOne(vm.ctx, host, []string{"name",
+			"summary", "runtime"}, &hsMo)
 		if err != nil {
 			return nil, err
 		}
@@ -1598,90 +1637,110 @@ func GetTemplateList(vm *VM) ([]map[string]interface{}, error) {
 		return nil, err
 	}
 
-	if vmMoList != nil {
-		for _, vmo := range vmMoList {
-			// Filter out the templates
-			if vmo.Config != nil && vmo.Config.Template {
-				devices := vmo.Config.Hardware.Device
-				diskInfo := make([]map[string]interface{}, 0)
-				for _, device := range devices {
-					disk, ok := device.(*types.VirtualDisk)
-					if !ok {
-						continue
-					}
-					devinfo := disk.DeviceInfo
-					backing := disk.Backing
-					fileBackingInfo := backing.(types.BaseVirtualDeviceFileBackingInfo).GetVirtualDeviceFileBackingInfo()
-					if di, ok := devinfo.(*types.Description); ok {
-						diskInfo = append(diskInfo, map[string]interface{}{
-							"name":      di.Label,
-							"size":      disk.CapacityInKB,
-							"disk_file": fileBackingInfo.FileName,
-						})
-					}
-				}
-				vmList = append(vmList, map[string]interface{}{
-					"name":           vmo.Name,
-					"id":             vmo.Self.Value,
-					"disks":          diskInfo,
-					"nic_info":       getNicInfo(vmo),
-					"memory_size_mb": vmo.Summary.Config.MemorySizeMB,
-					"num_cpu":        vmo.Summary.Config.NumCpu,
-				})
-			}
+	if vmMoList == nil {
+		return vmList, nil
+	}
+	for name, vmo := range vmMoList {
+		// Filter out the templates
+		if vmo.Config != nil && !vmo.Config.Template {
+			continue
 		}
+		diskInfo := make([]map[string]interface{}, 0)
+		for _, device := range vmo.Config.Hardware.Device {
+			disk, ok := device.(*types.VirtualDisk)
+			if !ok {
+				continue
+			}
+			devinfo, ok := disk.DeviceInfo.(*types.Description)
+			if !ok {
+				continue
+			}
+			backing := disk.Backing
+			fileBackingInfo := backing.(types.BaseVirtualDeviceFileBackingInfo).GetVirtualDeviceFileBackingInfo()
+			diskInfo = append(diskInfo, map[string]interface{}{
+				"name":      devinfo.Label,
+				"size":      disk.CapacityInKB,
+				"disk_file": fileBackingInfo.FileName,
+			})
+		}
+		vmList = append(vmList, map[string]interface{}{
+			"name":           name, // full name/path of vm
+			"id":             vmo.Self.Value,
+			"disks":          diskInfo,
+			"nic_info":       getNicInfo(vmo),
+			"memory_size_mb": vmo.Summary.Config.MemorySizeMB,
+			"num_cpu":        vmo.Summary.Config.NumCpu,
+		})
 	}
 	return vmList, nil
 }
 
-// getVirtualMachines : Return the virtual machines in a cluster
-func getVirtualMachines(vm *VM) ([]mo.VirtualMachine, error) {
+// getVirtualMachines : Return the virtual machines in a dc/cluster/host
+func getVirtualMachines(vm *VM) (map[string]mo.VirtualMachine, error) {
 	var (
-		vmList          []mo.VirtualMachine
-		virtualMachines []mo.VirtualMachine
-		hsMo            mo.HostSystem
+		vmsInDc, vmsInCluster map[string]mo.VirtualMachine
+		hsMos                 []mo.HostSystem
+		hsMo                  mo.HostSystem
 	)
+	vmsInDc = make(map[string]mo.VirtualMachine)
+	vmsInCluster = make(map[string]mo.VirtualMachine)
 	// set up session to vcenter server
 	if err := SetupSession(vm); err != nil {
 		return nil, err
 	}
 
-	if vm.Destination.DestinationName == "" {
-		// Return virtual machines for the whole datacenter
-		dcMo, err := GetDatacenter(vm)
-		if err != nil {
-			return nil, err
-		}
-
-		dcObj := object.NewDatacenter(vm.client.Client, dcMo.Reference())
-		return getDcVMList(vm, dcObj)
-	}
-
-	// set up session to vcenter server
-	dc, err := GetDatacenter(vm)
+	// Return virtual machines for the whole datacenter
+	dcMo, err := GetDatacenter(vm)
 	if err != nil {
 		return nil, err
+	}
+
+	dcObj := object.NewDatacenter(vm.client.Client,
+		dcMo.Reference())
+	vmsInDc, err = getDcVMList(vm, dcObj)
+	if err != nil {
+		return nil, err
+	}
+
+	if vm.Destination.DestinationName == "" {
+		return vmsInDc, nil
 	}
 
 	// Get the cluster resource and its host, datastore and datastore
-	crMo, err := findClusterComputeResource(vm, dc, vm.Destination.DestinationName)
+	crMo, err := findClusterComputeResource(vm, dcMo,
+		vm.Destination.DestinationName)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, host := range crMo.Host {
-		err = vm.collector.RetrieveOne(vm.ctx, host, []string{"name", "vm"}, &hsMo)
-		if err != nil {
-			return nil, err
-		}
-
-		err = vm.collector.Retrieve(vm.ctx, hsMo.Vm, []string{"name", "config", "summary"}, &virtualMachines)
-		if err != nil {
-			return nil, err
-		}
-		vmList = append(vmList, virtualMachines...)
+	err = vm.collector.Retrieve(vm.ctx, crMo.Host, []string{"name"}, &hsMos)
+	if err != nil {
+		return nil, err
 	}
-	return vmList, nil
+	hosts := make(map[string]string)
+	for _, host := range hsMos {
+		hosts[host.Name] = ""
+	}
+	if vm.Destination.HostSystem != "" {
+		hosts = map[string]string{
+			vm.Destination.HostSystem: "",
+		}
+	}
+
+	for path, vmMo := range vmsInDc {
+		if vmMo.Runtime.Host == nil {
+			continue
+		}
+		err = vm.collector.RetrieveOne(vm.ctx, *vmMo.Runtime.Host,
+			[]string{"name"}, &hsMo)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := hosts[hsMo.Name]; ok {
+			vmsInCluster[path] = vmMo
+		}
+	}
+	return vmsInCluster, nil
 }
 
 // ConvertToTemplate : converts vm to vm template

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -1438,10 +1438,19 @@ func getVmsInFolder(vm *VM, folder *object.Folder, path string) (
 			if err != nil {
 				return nil, err
 			}
+			// unescaping to convert any escaped character
+			folderName, err := url.QueryUnescape(folderMo.Name)
+			if err != nil {
+				return nil, err
+			}
+			// Adding delimitter in case "/" is present in name
+			folderName = strings.Replace(folderName, "/", "\\/",
+				-1)
 			folder := object.NewFolder(vm.client.Client,
 				mor)
+			// Getting vms in the folder
 			vms, err := getVmsInFolder(vm, folder,
-				path+folderMo.Name+"/")
+				path+folderName+"/")
 			if err != nil {
 				return nil, err
 			}
@@ -1455,7 +1464,14 @@ func getVmsInFolder(vm *VM, folder *object.Folder, path string) (
 			if err != nil {
 				return nil, err
 			}
-			vmName := path + vmMo.Name
+			// unescaping to convert any escaped character
+			vmName, err := url.QueryUnescape(vmMo.Name)
+			if err != nil {
+				return nil, err
+			}
+			// Adding delimitter in case "/" is present in name
+			vmName = path + strings.Replace(vmName, "/", "\\/",
+				-1)
 			allVms[vmName] = vmMo
 		}
 	}


### PR DESCRIPTION
**Jira-Id**

MRPHS-3895

**Problem**

Two vms/templates can have the same name if present in different directories. The current way to identify the vm/template by name does not recognise the vm uniquely. 
The Get virtual machine should be searched recursively the folders in the vcenter vm folder and send the complete path of the vm should be sent to the caller. The path can have special characters(even '/' which is a path separator). 

**Resolution**

Look for the vms recursively over the folders and return the full path of the vm as the vm name.
The searchTree method to look for the vms in vcenter should take the whole path of the vm and return the managed object of the vm.
To deal with the slash ('/') in vm/folder name, it is escaped if it is a part of name. So if a folder name is ```name/1```, it will be represented as ```name\/1```.

**Testing**

Done. Tried vm App template creation (fetching templates). Deploying app from template with four vms, having template names as below: ("/" in filename is replaced with "\/")

1) vms\/test\/rec/rec\/1/rhel\/template\/vm - (folder with slashes)
2) Templates/red\/hat/red%hat\/1 - (folder with slash and another special character)
3) Visor/visor_template_2.1 - (folder without slashes and special character
4) rhel - (template at root location)

The vm app deployed successfully. Tried shutdown, restart, reset, delete operation on the app. The operations are done successfully. Logs are attached below:

[c3ntry.txt](https://github.com/apporbit/libretto/files/1512675/c3ntry.txt)
