### PR TITLE
MRPHS-3906 : Restart operation is stuck at 33% when multiple operations ( stop and create ) are done in parallel

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -34,8 +34,9 @@ import (
 )
 
 const (
-	RETRY_COUNT          = 20
-	STATUS_CHECK_TIMEOUT = 5 * time.Minute
+	RETRY_COUNT                = 20
+	GRAY_STATUS_CHECK_TIMEOUT  = 1 * time.Minute
+	GREEN_STATUS_CHECK_TIMEOUT = 10 * time.Minute
 )
 
 /*
@@ -1018,9 +1019,10 @@ var restart = func(vm *VM) error {
 	}
 	// wait for machine to shutdown - status will turn to gray
 	// ignoring the error if timeout waiting for gray status
-	waitForGuestStatus(vm, vmMo, GRAY_HEART_BEAT, STATUS_CHECK_TIMEOUT)
+	waitForGuestStatus(vm, vmMo, GRAY_HEART_BEAT, GRAY_STATUS_CHECK_TIMEOUT)
 	// wait for machine to come up again - status will turn to green
-	err = waitForGuestStatus(vm, vmMo, GREEN_HEART_BEAT|YELLOW_HEART_BEAT)
+	err = waitForGuestStatus(vm, vmMo, GREEN_HEART_BEAT|YELLOW_HEART_BEAT,
+		GREEN_STATUS_CHECK_TIMEOUT)
 	if err != nil {
 		return fmt.Errorf("error wating for vm to reboot : %v", err)
 	}


### PR DESCRIPTION
**Jira Id**

MRPHS-3906

**Problem**

Restart operation is stuck at 33% when multiple operations ( stop and create ) are done in parallel. It takes some time till the guest status is updated after which only the restart/reset returns success. 

**Resolution**

Checking the status of the tools after resetting/restarting vm instead of guest status which takes lesser time.

**Testing**

Done. Tried various operations together. The operations are executed successfully. Tried shutdown after restart and reset which also worked fine. Logs are attached below:

[c3ntry.txt](https://github.com/apporbit/libretto/files/1509381/c3ntry.txt)
