### PR TITLE
MRPHS-3564: Add api call to validate credentials  for  creating vmware cloud

### DIFF
--- a/virtualmachine/aws/vm.go
+++ b/virtualmachine/aws/vm.go
@@ -846,3 +846,8 @@ func (vm *VM) ResetKeyPair() {
 	vm.SSHCreds.SSHPrivateKey = ""
 	vm.KeyPair = ""
 }
+
+// ValidateAuth: returns error if credentials are incorrect
+func (vm *VM) ValidateAuth() error {
+	return errors.New("Action : validate auth not supported")
+}

--- a/virtualmachine/gcp/vm.go
+++ b/virtualmachine/gcp/vm.go
@@ -403,9 +403,9 @@ func (vm *VM) GetNetworkList() ([]Network, error) {
 				convResURLToName(subnetworkURL))
 		}
 		response = append(response, Network{
-			Name:                  network.Name,
-			Description:           network.Description,
-			Id:                    network.Id,
+			Name:        network.Name,
+			Description: network.Description,
+			Id:          network.Id,
 			AutoCreateSubnetworks: &network.AutoCreateSubnetworks,
 			CreationTimestamp:     network.CreationTimestamp,
 			IPv4Range:             network.IPv4Range,
@@ -760,4 +760,9 @@ func (vm *VM) DeleteImage() error {
 	}
 
 	return s.deleteImage()
+}
+
+// ValidateAuth: returns error if credentials are incorrect
+func (vm *VM) ValidateAuth() error {
+	return errors.New("Action : validate auth not supported")
 }

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -1711,3 +1711,12 @@ func ConvertToTemplate(vm *VM) error {
 	}
 	return nil
 }
+
+// ValidateAuth: returns error if vcenter credentials are incorrect
+func (vm *VM) ValidateAuth() error {
+	if err := SetupSession(vm); err != nil {
+		return err
+	}
+	defer vm.cancel()
+	return nil
+}


### PR DESCRIPTION
### Symptom:
[MRPHS-3564](https://apporbit.atlassian.net/browse/MRPHS-3564)

Add api call to validate invalid credentials  for  creating vmware cloud

### Description:

Add api call to validate invalid credentials  for  creating vmware cloud

### Resolution:

Added ValidateAuth to validate the credentials.

### Testing:

**Unit Testing:**

Done. Tried validating the vcenter auth using ValidateAuth Call. 
Case 1: Correct details: Authorisation check is successful.

```
[root@my_machine test]#
[root@my_machine test]# go run vsphereclient.go  validate_auth
file Name :  validate_auth.json
Authorization successfull
[root@my_machine test]#
```

Case 2: Incorrect details: Returned error 

```
[root@my_machine test]# go run vsphereclient.go  validate_auth
file Name :  validate_auth.json
error connecting to the VI SDK: Post https://209.205.216.111/sdk: dial tcp 209.205.216.111:443: i/o timeout
[root@my_machine test]#
```

**Automated testing:**

NR

### Notes for reviewing:

<Order for reviewing>
<Other related PRs>
<Reason for smoke failure or smoke not done>
