### PR TITLE
[DO NOT MERGE] MRPHS-3918: Updated AddDisk to send appropriate err in case of failure and RemoveDisk to use DiskName

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -998,13 +998,6 @@ var reconfigureVM = func(vm *VM, vmMo *mo.VirtualMachine) error {
 	}
 
 	for index, disk := range vm.Disks {
-		// getting device list before adding this disk
-		devListBefore, err := vmObj.Device(vm.ctx)
-		if err != nil {
-			return fmt.Errorf("Failed to get devices before creating "+
-				"Disks[%d] {%v} : %v", index, disk, err)
-		}
-
 		// root disk datastore is used by default
 		if disk.Datastore == "" {
 			datastore = vm.datastore
@@ -1031,6 +1024,10 @@ var reconfigureVM = func(vm *VM, vmMo *mo.VirtualMachine) error {
 		} else {
 			thinProvisioned = true
 		}
+
+		// getting device list before adding this disk
+		devListBefore := devices
+
 		vDisk = CreateDisk(devices, controller, dsMo.Reference(), "",
 			thinProvisioned)
 		vDisk.CapacityInKB = disk.Size
@@ -1041,12 +1038,12 @@ var reconfigureVM = func(vm *VM, vmMo *mo.VirtualMachine) error {
 
 		// getting device list after adding disk and setting appropriate
 		// vmdk filename to DiskName
-		devListAfter, err := vmObj.Device(vm.ctx)
+		devices, err = vmObj.Device(vm.ctx)
 		if err != nil {
 			return fmt.Errorf("Failed to get devices after creating "+
 				"Disks[%d] {%v} : %v", index, disk, err)
 		}
-		vmdkFilename := diffDisks(devListAfter, devListBefore)
+		vmdkFilename := diffDisks(devices, devListBefore)
 		vm.Disks[index].DiskName = vmdkFilename[0]
 	}
 

--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -894,7 +894,7 @@ var cloneFromTemplate = func(vm *VM, dcMo *mo.Datacenter, usableDatastores []str
 		return fmt.Errorf("failed to retrieve cloned VM: %v", err)
 	}
 	if len(vm.Disks) > 0 {
-		if _, err = reconfigureVM(vm, vmMo); err != nil {
+		if err = reconfigureVM(vm, vmMo); err != nil {
 			return err
 		}
 	}
@@ -976,7 +976,7 @@ var getDatastoreForVm = func(vm *VM, vmMo *mo.VirtualMachine) ([]string,
 // reconfigureVM :reconfigureVM adds the disks to the vm and returns the vmdk
 // file names of the disks added
 // root disk datastore is used by default
-var reconfigureVM = func(vm *VM, vmMo *mo.VirtualMachine) ([]string, error) {
+var reconfigureVM = func(vm *VM, vmMo *mo.VirtualMachine) error {
 	var (
 		vDisk           *types.VirtualDisk
 		thinProvisioned bool
@@ -984,25 +984,27 @@ var reconfigureVM = func(vm *VM, vmMo *mo.VirtualMachine) ([]string, error) {
 	)
 	vmObj := object.NewVirtualMachine(vm.client.Client, vmMo.Reference())
 
-	devList1, err := vmObj.Device(vm.ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	dcMo, err := GetDatacenter(vm)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	if vm.datastore == "" {
 		datastores, err := getDatastoreForVm(vm, vmMo)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		vm.datastore = util.ChooseRandomString(datastores)
 	}
 
-	for _, disk := range vm.Disks {
+	for index, disk := range vm.Disks {
+		// getting device list before adding this disk
+		devListBefore, err := vmObj.Device(vm.ctx)
+		if err != nil {
+			return fmt.Errorf("Failed to get devices before creating "+
+				"Disks[%d] {%v} : %v", index, disk, err)
+		}
+
 		// root disk datastore is used by default
 		if disk.Datastore == "" {
 			datastore = vm.datastore
@@ -1011,15 +1013,18 @@ var reconfigureVM = func(vm *VM, vmMo *mo.VirtualMachine) ([]string, error) {
 		}
 		devices, err := vmObj.Device(vm.ctx)
 		if err != nil {
-			return nil, err
+			return fmt.Errorf("Failed to get devices while creating "+
+				"Disks[%d] {%v} : %v", index, disk, err)
 		}
 		controller, err := devices.FindDiskController(disk.Controller)
 		if err != nil {
-			return nil, err
+			return fmt.Errorf("Failed to get controller while creating "+
+				"Disks[%d] {%v} : %v", index, disk, err)
 		}
 		dsMo, err := findDatastore(vm, dcMo, datastore)
 		if err != nil {
-			return nil, err
+			return fmt.Errorf("Failed to get datastore while creating "+
+				"Disks[%d] {%v} : %v", index, disk, err)
 		}
 		if strings.ToLower(disk.Provisioning) == "thick" {
 			thinProvisioned = false
@@ -1030,17 +1035,22 @@ var reconfigureVM = func(vm *VM, vmMo *mo.VirtualMachine) ([]string, error) {
 			thinProvisioned)
 		vDisk.CapacityInKB = disk.Size
 		if err := vmObj.AddDevice(vm.ctx, vDisk); err != nil {
-			return nil, err
+			return fmt.Errorf("Failed to add device while creating "+
+				"Disks[%d] {%v} : %v", index, disk, err)
 		}
+
+		// getting device list after adding disk and setting appropriate
+		// vmdk filename to DiskName
+		devListAfter, err := vmObj.Device(vm.ctx)
+		if err != nil {
+			return fmt.Errorf("Failed to get devices after creating "+
+				"Disks[%d] {%v} : %v", index, disk, err)
+		}
+		vmdkFilename := diffDisks(devListAfter, devListBefore)
+		vm.Disks[index].DiskName = vmdkFilename[0]
 	}
 
-	devList2, err := vmObj.Device(vm.ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	disks := diffDisks(devList2, devList1)
-	return disks, nil
+	return nil
 }
 
 var waitForIP = func(vm *VM, vmMo *mo.VirtualMachine) error {

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -722,7 +722,7 @@ func (vm *VM) RemoveDisk() error {
 			switch device := d.(type) {
 			case *types.VirtualDisk:
 				fileName := d.GetVirtualDevice().Backing.(types.BaseVirtualDeviceFileBackingInfo).GetVirtualDeviceFileBackingInfo().FileName
-				if strings.HasSuffix(fileName, disk.DiskName) {
+				if fileName == disk.DiskName {
 					deviceMo = device
 					break
 				}

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -657,10 +657,10 @@ func (vm *VM) GetName() string {
 	return vm.Name
 }
 
-// AddDisk to the vm
-func (vm *VM) AddDisk() ([]string, error) {
+// AddDisk: adds given list of disks to the vm
+func (vm *VM) AddDisk() error {
 	if err := SetupSession(vm); err != nil {
-		return nil, fmt.Errorf("Error setting up vSphere session: %v", err)
+		return fmt.Errorf("Error setting up vSphere session: %v", err)
 	}
 
 	// Cancel the sdk context
@@ -669,13 +669,13 @@ func (vm *VM) AddDisk() ([]string, error) {
 	// Get a reference to the datacenter with host and vm folders populated
 	dcMo, err := GetDatacenter(vm)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to retrieve datacenter: %v", err)
+		return fmt.Errorf("Failed to retrieve datacenter: %v", err)
 	}
 
 	// Finds the vm with name vm.Name
 	vmMo, err := findVM(vm, dcMo, vm.Name)
 	if err != nil {
-		return nil, fmt.Errorf("VM :%s not found. Error : %v",
+		return fmt.Errorf("VM :%s not found. Error : %v",
 			vm.Name, err)
 	}
 
@@ -683,15 +683,17 @@ func (vm *VM) AddDisk() ([]string, error) {
 	vm.datastore = util.ChooseRandomString(vm.Datastores)
 
 	// Reconfigures vm with the new Disk
-	diskList, err := reconfigureVM(vm, vmMo)
+	err = reconfigureVM(vm, vmMo)
 	if err != nil {
-		return nil, fmt.Errorf("Reconfigure failed : %v", err)
+		return fmt.Errorf("Reconfigure failed : %v", err)
 	}
-	return diskList, nil
+
+	return nil
 }
 
-// RemoveDisk removes the disk attached to the virtualmachine 'vm', vmdkName is the name of the vmdk file for the disk
-func (vm *VM) RemoveDisk(vmdkFiles []string) error {
+// RemoveDisk: removes given list of disks attached to the virtualmachine 'vm'
+// disk.DiskName is the name of the vmdk file for the disk
+func (vm *VM) RemoveDisk() error {
 	var errorMessage string
 	if err := SetupSession(vm); err != nil {
 		return fmt.Errorf("Error setting up vSphere session: %v", err)
@@ -706,7 +708,7 @@ func (vm *VM) RemoveDisk(vmdkFiles []string) error {
 		return fmt.Errorf("Failed to retrieve datacenter: %v", err)
 	}
 
-	for _, vmdkName := range vmdkFiles {
+	for _, disk := range vm.Disks {
 		// finds the virtualmachine with name vm.Name
 		vmMo, err := findVM(vm, dcMo, vm.Name)
 		if err != nil {
@@ -720,7 +722,7 @@ func (vm *VM) RemoveDisk(vmdkFiles []string) error {
 			switch device := d.(type) {
 			case *types.VirtualDisk:
 				fileName := d.GetVirtualDevice().Backing.(types.BaseVirtualDeviceFileBackingInfo).GetVirtualDeviceFileBackingInfo().FileName
-				if strings.HasSuffix(fileName, vmdkName) {
+				if strings.HasSuffix(fileName, disk.DiskName) {
 					deviceMo = device
 					break
 				}
@@ -728,14 +730,14 @@ func (vm *VM) RemoveDisk(vmdkFiles []string) error {
 		}
 
 		if deviceMo == nil {
-			errorMessage += fmt.Sprintf("%s : No disk with name\n", vmdkName)
+			errorMessage += fmt.Sprintf("%s : No disk with name\n", disk.DiskName)
 			continue
 		}
 
 		// Creates the virtualmachine object to remove the disk
 		vmo := object.NewVirtualMachine(vm.client.Client, vmMo.Reference())
 		if err = vmo.RemoveDevice(vm.ctx, false, deviceMo); err != nil {
-			errorMessage += fmt.Errorf("%s : Delete disk task returned an error : %s \n", vmdkName, err).Error()
+			errorMessage += fmt.Errorf("%s : Delete disk task returned an error : %s \n", disk.DiskName, err).Error()
 		}
 	}
 	if errorMessage != "" {


### PR DESCRIPTION
**Jira Id**

[MRPHS-3917](https://apporbit.atlassian.net/browse/MRPHS-3918)

**Problem**

Currently AddDisk just returns error without any information of index or name of disk for which it occur in case of failure. So there is not information of how many disks are created from a given list.
RemoveDisk receives list of vmdk files names as separate parameter, though we have DiskName parameter in Disk struct which is used to store vmdk file name.

**Resolution**

reconfigureVM is modified to return err with appropriate disk index and its values for which it occured and also returns updated vm struct with updated disk information so that how many disks are created before failure can be seen.

RemoveDisk is updated to use DiskName parameter of Disk struct instead of separate list of vmdk file names.

**Testing**

Unit tested all the AddDisk and RemoveDisk operations with dummy client. Logs attached.
[c3_add_delete_volume.log](https://github.com/apporbit/libretto/files/1521080/c3_add_delete_volume.log)

**Note:**
This change will require change in Halo and Appos(C3ntry).
PR for Halo: [MRPHS-3918](https://github.com/apporbit/halo/pull/65)
PR for Appos(C3ntry):  [MRPHS-3920](https://github.com/apporbit/appos/pull/281)