### PR TITLE
MRPHS-3796 : Resize (increase) existing volumes in VM template

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -594,6 +594,7 @@ func removeExistingNetworks(vm *VM, vmObj *object.VirtualMachine) ([]types.BaseV
 	return removeSpecs, nil
 }
 
+// Function to search disk in disks array with its name
 func findByVirtualDeviceFileName(disks []Disk, name string) *Disk {
 	for _, disk := range disks {
 		if disk.DiskName == name {
@@ -713,7 +714,7 @@ var cloneFromTemplate = func(vm *VM, dcMo *mo.Datacenter, usableDatastores []str
 	}
 	config.DeviceChange = deviceChangeSpec
 
-	//Resize (increase)/delete existing volumes in VM template
+	// Resize (increase)/delete existing volumes in VM template
 	conf, err := resizeAndDeleteVols(*vmMo, vm.FixedDisks)
 	config.DeviceChange = append(config.DeviceChange, conf...)
 	if err != nil {

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -533,6 +533,8 @@ type VM struct {
 	SkipExisting int
 	// Credentials are the credentials to use when connecting to the VM over SSH
 	Credentials ssh.Credentials
+	//FixedDisks is a slice of existing disks which user wants to either expand/delete from VM
+	FixedDisks []Disk
 	// Disks is a slice of extra disks to attach to the VM
 	Disks []Disk
 	// QuestionResponses is a map of regular expressions to match question text

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -533,7 +533,7 @@ type VM struct {
 	SkipExisting int
 	// Credentials are the credentials to use when connecting to the VM over SSH
 	Credentials ssh.Credentials
-	//FixedDisks is a slice of existing disks which user wants to either expand/delete from VM
+	// FixedDisks is a slice of existing disks which user wants to either expand/delete from VM
 	FixedDisks []Disk
 	// Disks is a slice of extra disks to attach to the VM
 	Disks []Disk


### PR DESCRIPTION
https://apporbit.atlassian.net/browse/MRPHS-3796

Context
===========
Currently we have provided flexibility to add new volume while building a VM template. Add capability to edit and extend exiting template.
doc link : https://docs.google.com/document/d/1Ynd7YtSY-JB5OhLDGE9F42mem6usmn64TmvHo4k_fdY/edit?pli=1#

Related changes
----------------
Added code for expanding, deleting disks as per the users requirement

============
```
Testing done on local setup end to end by editing app template....
App template 
name: FinalTest
version: '2'
tiers:
  - name: new-tier
    type: ''
    replicas: 3
    containers: []
    vms: []
    vmachines:
      - name: new_vm
        image: Deepali_Template_multidisk
        vm_template_id: vm-1246
        config:
          cpu: 2
          memory: 4096
          fixed_disks:
            - disk-size: 20G
              disk-file: >-
                [datastore4-130-4TB-SATA]
                Deepali_Template_multidisk/Deepali_Template_multidisk_3.vmdk
            - disk-size: 157G
              disk-file: >-
                [datastore4-130-4TB-SATA]
                Deepali_Template_multidisk/Deepali_Template_multidisk.vmdk
            - disk-size: 102G
              disk-file: >-
                [datastore4-130-4TB-SATA]
                Deepali_Template_multidisk/Deepali_Template_multidisk_1.vmdk
        networks:
          - VM Network
        environment: []
        ports: []
        volumes:
          - volume-size: 30G
            type: scsi
            provision: thin
        internalPortCount: 0
        externalPortCount: 0
networks: {}
services: []
policies: []
cloud: VMwareStartling
location:
  vcluster: Cluster1


c3ntry log :
[root@deepali-dev3 example]# go run  c3ntry_client.go
Sending request:
action:"create_vms" args:"{\"Insecure\":true,\"cloud_type\":\"vsphere\",\"type\":\"PUBLIC\",\"Host\":\"starling-vcenter.gsintlab.com\",\"Username\":\"bhanu@vsphere.local\",\"Password\":\"$***\",\"Datacenter\":\"Starling-DC\",\"Destination\":{\"DestinationName\":\"Cluster1\",\"DestinationType\":\"cluster\",\"HostSystem\":\"\"},\"Datastores\":[\"datastore1-130-1TB-SSD\"],\"cluster_name\":\"Cluster1\",\"network\":{\"networks\":[{\"name\":\"VM Network\"}]},\"skip_ip_wait\":true,\"simple_name\":true,\"custom_suffix\":\"20171128114436\",\"cluster\":[{\"gid\":0,\"name\":\"delete_just2new_vm_deeleete\",\"count\":3,\"flavor\":\"custom\",\"resources\":{\"cpu\":2,\"memory\":4096,\"fixed_disks\":[[{\"Size\":20,\"DiskName\":\"[datastore4-130-4TB-SATA] Deepali_Template_multidisk/Deepali_Template_multidisk_2.vmdk\"}], [{\"Size\":20,\"DiskName\":\"[datastore4-130-4TB-SATA] Deepali_Template_multidisk/Deepali_Template_multidisk_2.vmdk\"}], [{\"Size\":20,\"DiskName\":\"[datastore4-130-4TB-SATA] Deepali_Template_multidisk/Deepali_Template_multidisk_2.vmdk\"}]]},\"image\":{\"Template\":\"Deepali_Template_multidisk\",\"SkipExisting\":2},\"volumes\":null}]}" id:"app:8:deploy"

2017/12/01 11:30:58 Received Response:
result:"{\"0\":{\"1\":{\"vm_name\":\"delete_just2new_vm_deeleete-0-20171128114436\",\"instance_id\":\"delete_just2new_vm_deeleete-0-20171128114436\",\"vm_id\":\"vm-1309\"},\"2\":{\"vm_name\":\"delete_just2new_vm_deeleete-1-20171128114436\",\"instance_id\":\"delete_just2new_vm_deeleete-1-20171128114436\",\"vm_id\":\"vm-1311\"},\"3\":{\"vm_name\":\"delete_just2new_vm_deeleete-2-20171128114436\",\"instance_id\":\"delete_just2new_vm_deeleete-2-20171128114436\",\"vm_id\":\"vm-1310\"},\"gid\":\"0\"}}" id:"app:8:deploy" progress:100

2017/12/01 11:30:58 Response String:
{"result":"{\"0\":{\"1\":{\"vm_name\":\"delete_just2new_vm_deeleete-0-20171128114436\",\"instance_id\":\"delete_just2new_vm_deeleete-0-20171128114436\",\"vm_id\":\"vm-1309\"},\"2\":{\"vm_name\":\"delete_just2new_vm_deeleete-1-20171128114436\",\"instance_id\":\"delete_just2new_vm_deeleete-1-20171128114436\",\"vm_id\":\"vm-1311\"},\"3\":{\"vm_name\":\"delete_just2new_vm_deeleete-2-20171128114436\",\"instance_id\":\"delete_just2new_vm_deeleete-2-20171128114436\",\"vm_id\":\"vm-1310\"},\"gid\":\"0\"}}","id":"app:8:deploy","progress":100}

2017/12/01 11:30:58 Breaking..
[root@deepali-dev3 example]#
