### PR TITLE
MRPHS-4025 : Fetch template disks information of VMs as part of fetching template …

### DIFF
--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -1608,10 +1608,13 @@ func GetTemplateList(vm *VM) ([]map[string]interface{}, error) {
 						continue
 					}
 					devinfo := disk.DeviceInfo
+					backing := disk.Backing
+					fileBackingInfo := backing.(types.BaseVirtualDeviceFileBackingInfo).GetVirtualDeviceFileBackingInfo()
 					if di, ok := devinfo.(*types.Description); ok {
 						diskInfo = append(diskInfo, map[string]interface{}{
-							"name": di.Label,
-							"size": disk.CapacityInKB,
+							"name":      di.Label,
+							"size":      disk.CapacityInKB,
+							"disk_file": fileBackingInfo.FileName,
 						})
 					}
 				}


### PR DESCRIPTION
https://apporbit.atlassian.net/browse/MRPHS-4025

Context
===========
Fetch template disks information of VMs as part of fetching template lists info

Related changes
----------------
Added code for getting vmdk disks name for templates.

============
```
[root@deepali-dev3 example]# go run c3ntry_client.go
Sending request:
action:"get_template_vm_list" args:"{\"Insecure\":true,\"cloud_type\":\"vsphere\",\"type\":\"PUBLIC\",\"Host\":\"starling-vcenter.gsintlab.com\",\"Username\":\"bhanu@vsphere.local\",\"Password\":\"***\",\"Datacenter\":\"Starling-DC\",\"Destination\":{\"DestinationName\":\"Cluster1\",\"DestinationType\":\"cluster\",\"HostSystem\":\"\"},\"Datastores\":[\"datastore1-130-1TB-SSD\"],\"cluster_name\":\"Cluster1\",\"network\":{\"networks\":[{\"name\":\"VM Network\"}]},\"skip_ip_wait\":true,\"simple_name\":true,\"custom_suffix\":\"20171128114436\",\"cluster\":[{\"gid\":0,\"name\":\"delete_just2new_vm_deeleete\",\"count\":3,\"flavor\":\"custom\",\"resources\":{\"cpu\":2,\"memory\":4096,\"fixed_disks\":[[{\"Size\":20,\"DiskName\":\"[datastore4-130-4TB-SATA] Deepali_Template_multidisk/Deepali_Template_multidisk_2.vmdk\"}], [{\"Size\":20,\"DiskName\":\"[datastore4-130-4TB-SATA] Deepali_Template_multidisk/Deepali_Template_multidisk_2.vmdk\"}], [{\"Size\":20,\"DiskName\":\"[datastore4-130-4TB-SATA] Deepali_Template_multidisk/Deepali_Template_multidisk_2.vmdk\"}]]},\"image\":{\"Template\":\"Deepali_Template_multidisk\",\"SkipExisting\":2},\"volumes\":null}]}" id:"app:8:deploy"

2017/12/02 09:20:48 Received Response:
result:"[{\"disks\":[{\"disk_file\":\"[datastore4-130-4TB-SATA] Deepali_Template_multidisk/Deepali_Template_multidisk.vmdk\",\"name\":\"Hard disk 1\",\"size\":157286400},{\"disk_file\":\"[datastore4-130-4TB-SATA] Deepali_Template_multidisk/Deepali_Template_multidisk_1.vmdk\",\"name\":\"Hard disk 2\",\"size\":102400000},{\"disk_file\":\"[datastore4-130-4TB-SATA] Deepali_Template_multidisk/Deepali_Template_multidisk_3.vmdk\",\"name\":\"Hard disk 3\",\"size\":10485760},{\"disk_file\":\"[datastore4-130-4TB-SATA] Deepali_Template_multidisk/Deepali_Template_multidisk_2.vmdk\",\"name\":\"Hard disk 4\",\"size\":10485760}],\"id\":\"vm-1246\",\"memory_size_mb\":4096,\"name\":\"Deepali_Template_multidisk\",\"nic_info\":[{\"network_name\":\"VM Network\",\"mac_address\":\"00:50:56:91:6d:1a\",\"nic_name\":\"Network adapter 1\"}],\"num_cpu\":2},{\"disks\":[{\"disk_file\":\"[datastore4-130-4TB-SATA] starling-vcenter-template/starling-vcenter-template.vmdk\",\"name\":\"Hard disk 1\",\"size\":209715200}],\"id\":\"vm-241\",\"memory_size_mb\":12288,\"name\":\"starling-vcenter-template\",\"nic_info\":[{\"network_name\":\"VM Network\",\"mac_address\":\"00:50:56:91:49:84\",\"nic_name\":\"Network adapter 1\"},{\"network_name\":\"VM Private\",\"mac_address\":\"00:50:56:91:8d:5e\",\"nic_name\":\"Network adapter 2\"}],\"num_cpu\":16},{\"disks\":[{\"disk_file\":\"[datastore3-130-4TB-SATA] saur-online-1/saur-online-1.vmdk\",\"name\":\"Hard disk 1\",\"size\":104857600},{\"disk_file\":\"[datastore3-130-4TB-SATA] saur-online-1/saur-online-1_1.vmdk\",\"name\":\"Hard disk 2\",\"size\":104857600},{\"disk_file\":\"[datastore3-130-4TB-SATA] saur-online-1/saur-online-1_2.vmdk\",\"name\":\"Hard disk 3\",\"size\":52428800}],\"id\":\"vm-353\",\"memory_size_mb\":8192,\"name\":\"saur-online-1\",\"nic_info\":[{\"network_name\":\"VM Network\",\"mac_address\":\"00:50:56:91:bb:9a\",\"nic_name\":\"Network adapter 1\"},{\"network_name\":\"VM Private\",\"mac_address\":\"00:50:56:91:39:53\",\"nic_name\":\"Network adapter 2\"}],\"num_cpu\":4},{\"disks\":[{\"disk_file\":\"[datastore3-130-4TB-SATA] RHEL_7.2_TEMPLATE/RHEL_7.2_TEMPLATE.vmdk\",\"name\":\"Hard disk 1\",\"size\":209715200}],\"id\":\"vm-604\",\"memory_size_mb\":8192,\"name\":\"RHEL_7.2_TEMPLATE\",\"nic_info\":[{\"network_name\":\"VM Private\",\"mac_address\":\"00:50:56:91:12:4e\",\"nic_name\":\"Network adapter 1\"}],\"num_cpu\":4},{\"disks\":[{\"disk_file\":\"[datastore3-130-4TB-SATA] template_redhat_7.3_Fresh/template_redhat_7.3_Fresh.vmdk\",\"name\":\"Hard disk 1\",\"size\":209715200}],\"id\":\"vm-693\",\"memory_size_mb\":8192,\"name\":\"template_redhat_7.3_Fresh\",\"nic_info\":[{\"network_name\":\"VM Private\",\"mac_address\":\"00:50:56:91:9a:ac\",\"nic_name\":\"Network adapter 1\"}],\"num_cpu\":2},{\"disks\":[{\"disk_file\":\"[datastore4-130-4TB-SATA] Deepali_Template_multidisk/Deepali_Template_multidisk.vmdk\",\"name\":\"Hard disk 1\",\"size\":157286400},{\"disk_file\":\"[datastore4-130-4TB-SATA] Deepali_Template_multidisk/Deepali_Template_multidisk_1.vmdk\",\"name\":\"Hard disk 2\",\"size\":102400000},{\"disk_file\":\"[datastore4-130-4TB-SATA] Deepali_Template_multidisk/Deepali_Template_multidisk_3.vmdk\",\"name\":\"Hard disk 3\",\"size\":10485760},{\"disk_file\":\"[datastore4-130-4TB-SATA] Deepali_Template_multidisk/Deepali_Template_multidisk_2.vmdk\",\"name\":\"Hard disk 4\",\"size\":10485760}],\"id\":\"vm-1246\",\"memory_size_mb\":4096,\"name\":\"Deepali_Template_multidisk\",\"nic_info\":[{\"network_name\":\"VM Network\",\"mac_address\":\"00:50:56:91:6d:1a\",\"nic_name\":\"Network adapter 1\"}],\"num_cpu\":2},{\"disks\":[{\"disk_file\":\"[datastore4-130-4TB-SATA] starling-vcenter-template/starling-vcenter-template.vmdk\",\"name\":\"Hard disk 1\",\"size\":209715200}],\"id\":\"vm-241\",\"memory_size_mb\":12288,\"name\":\"starling-vcenter-template\",\"nic_info\":[{\"network_name\":\"VM Network\",\"mac_address\":\"00:50:56:91:49:84\",\"nic_name\":\"Network adapter 1\"},{\"network_name\":\"VM Private\",\"mac_address\":\"00:50:56:91:8d:5e\",\"nic_name\":\"Network adapter 2\"}],\"num_cpu\":16},{\"disks\":[{\"disk_file\":\"[datastore3-130-4TB-SATA] saur-online-1/saur-online-1.vmdk\",\"name\":\"Hard disk 1\",\"size\":104857600},{\"disk_file\":\"[datastore3-130-4TB-SATA] saur-online-1/saur-online-1_1.vmdk\",\"name\":\"Hard disk 2\",\"size\":104857600},{\"disk_file\":\"[datastore3-130-4TB-SATA] saur-online-1/saur-online-1_2.vmdk\",\"name\":\"Hard disk 3\",\"size\":52428800}],\"id\":\"vm-353\",\"memory_size_mb\":8192,\"name\":\"saur-online-1\",\"nic_info\":[{\"network_name\":\"VM Network\",\"mac_address\":\"00:50:56:91:bb:9a\",\"nic_name\":\"Network adapter 1\"},{\"network_name\":\"VM Private\",\"mac_address\":\"00:50:56:91:39:53\",\"nic_name\":\"Network adapter 2\"}],\"num_cpu\":4},{\"disks\":[{\"disk_file\":\"[datastore3-130-4TB-SATA] RHEL_7.2_TEMPLATE/RHEL_7.2_TEMPLATE.vmdk\",\"name\":\"Hard disk 1\",\"size\":209715200}],\"id\":\"vm-604\",\"memory_size_mb\":8192,\"name\":\"RHEL_7.2_TEMPLATE\",\"nic_info\":[{\"network_name\":\"VM Private\",\"mac_address\":\"00:50:56:91:12:4e\",\"nic_name\":\"Network adapter 1\"}],\"num_cpu\":4},{\"disks\":[{\"disk_file\":\"[datastore3-130-4TB-SATA] template_redhat_7.3_Fresh/template_redhat_7.3_Fresh.vmdk\",\"name\":\"Hard disk 1\",\"size\":209715200}],\"id\":\"vm-693\",\"memory_size_mb\":8192,\"name\":\"template_redhat_7.3_Fresh\",\"nic_info\":[{\"network_name\":\"VM Private\",\"mac_address\":\"00:50:56:91:9a:ac\",\"nic_name\":\"Network adapter 1\"}],\"num_cpu\":2},{\"disks\":[{\"disk_file\":\"[iSCSI-SAN-Storage1] dh12-vm1-0-20171122135613/dh12-vm1-0-20171122135613.vmdk\",\"name\":\"Hard disk 1\",\"size\":51200000},{\"disk_file\":\"[iSCSI-SAN-Storage1] dh12-vm1-0-20171122135613/dh12-vm1-0-20171122135613_1.vmdk\",\"name\":\"Hard disk 2\",\"size\":102400000}],\"id\":\"vm-1228\",\"memory_size_mb\":4096,\"name\":\"dh12-vm1-0-20171122135613\",\"nic_info\":null,\"num_cpu\":2},{\"disks\":[{\"disk_file\":\"[datastore1-131-1TB-SSD] Template-RHEL73/Template-RHEL73_0.vmdk\",\"name\":\"Hard disk 1\",\"size\":52428800}],\"id\":\"vm-23\",\"memory_size_mb\":4096,\"name\":\"Template-RHEL73\",\"nic_info\":[{\"network_name\":\"VM Private\",\"mac_address\":\"00:0c:29:52:ed:4d\",\"nic_name\":\"Network adapter 1\"},{\"network_name\":\"VM Network\",\"mac_address\":\"00:0c:29:52:ed:57\",\"nic_name\":\"Network adapter 2\"}],\"num_cpu\":2},{\"disks\":[{\"disk_file\":\"[datastore4-131-4TB-SATA] CentOS73-Template-public-network/CentOS73-Template-public-network.vmdk\",\"name\":\"Hard disk 1\",\"size\":104857600}],\"id\":\"vm-38\",\"memory_size_mb\":4096,\"name\":\"CentOS73-Template-public-network\",\"nic_info\":[{\"network_name\":\"VM Network\",\"mac_address\":\"00:50:56:91:e4:57\",\"nic_name\":\"Network adapter 1\"},{\"network_name\":\"VM Private\",\"mac_address\":\"00:50:56:91:0b:ee\",\"nic_name\":\"Network adapter 2\"}],\"num_cpu\":2},{\"disks\":[{\"disk_file\":\"[datastore4-131-4TB-SATA] centos73-Template-public-private/centos73-Template-public-private.vmdk\",\"name\":\"Hard disk 1\",\"size\":104857600}],\"id\":\"vm-40\",\"memory_size_mb\":4096,\"name\":\"centos73-Template-public-private\",\"nic_info\":[{\"network_name\":\"VM Network\",\"mac_address\":\"00:50:56:91:0c:f0\",\"nic_name\":\"Network adapter 1\"},{\"network_name\":\"VM Private\",\"mac_address\":\"00:50:56:91:16:31\",\"nic_name\":\"Network adapter 2\"}],\"num_cpu\":2},{\"disks\":[{\"disk_file\":\"[datastore3-131-4TB-SATA] Template-win/Template-win.vmdk\",\"name\":\"Hard disk 1\",\"size\":10485760}],\"id\":\"vm-403\",\"memory_size_mb\":4096,\"name\":\"Template-win\",\"nic_info\":[{\"network_name\":\"VM Private\",\"mac_address\":\"00:50:56:91:ce:3a\",\"nic_name\":\"Network adapter 1\"}],\"num_cpu\":1},{\"disks\":[{\"disk_file\":\"[datastore3-131-4TB-SATA] visor_template_2.1/visor_template_2.1.vmdk\",\"name\":\"Hard disk 1\",\"size\":51200000},{\"disk_file\":\"[datastore3-131-4TB-SATA] visor_template_2.1/visor_template_2.1_1.vmdk\",\"name\":\"Hard disk 2\",\"size\":102400000}],\"id\":\"vm-418\",\"memory_size_mb\":4096,\"name\":\"visor_template_2.1\",\"nic_info\":[{\"network_name\":\"VM Network\",\"mac_address\":\"00:50:56:91:a2:b4\",\"nic_name\":\"Network adapter 1\"}],\"num_cpu\":2},{\"disks\":[{\"disk_file\":\"[datastore4-131-4TB-SATA] Ankit-template/Ankit-template.vmdk\",\"name\":\"Hard disk 1\",\"size\":104857600},{\"disk_file\":\"[datastore4-131-4TB-SATA] Ankit-template/Ankit-template_1.vmdk\",\"name\":\"Hard disk 2\",\"size\":209715200},{\"disk_file\":\"[datastore4-131-4TB-SATA] Ankit-template/Ankit-template_2.vmdk\",\"name\":\"Hard disk 3\",\"size\":104857600}],\"id\":\"vm-463\",\"memory_size_mb\":8192,\"name\":\"Ankit-template\",\"nic_info\":[{\"network_name\":\"VM Network\",\"mac_address\":\"00:50:56:91:93:ba\",\"nic_name\":\"Network adapter 1\"},{\"network_name\":\"VM Private\",\"mac_address\":\"00:50:56:91:f0:f8\",\"nic_name\":\"Network adapter 2\"}],\"num_cpu\":4}]" id:"app:8:deploy" progress:100

2017/12/02 09:20:48 Response String:
{"result":"[{\"disks\":[{\"disk_file\":\"[datastore4-130-4TB-SATA] Deepali_Template_multidisk/Deepali_Template_multidisk.vmdk\",\"name\":\"Hard disk 1\",\"size\":157286400},{\"disk_file\":\"[datastore4-130-4TB-SATA] Deepali_Template_multidisk/Deepali_Template_multidisk_1.vmdk\",\"name\":\"Hard disk 2\",\"size\":102400000},{\"disk_file\":\"[datastore4-130-4TB-SATA] Deepali_Template_multidisk/Deepali_Template_multidisk_3.vmdk\",\"name\":\"Hard disk 3\",\"size\":10485760},{\"disk_file\":\"[datastore4-130-4TB-SATA] Deepali_Template_multidisk/Deepali_Template_multidisk_2.vmdk\",\"name\":\"Hard disk 4\",\"size\":10485760}],\"id\":\"vm-1246\",\"memory_size_mb\":4096,\"name\":\"Deepali_Template_multidisk\",\"nic_info\":[{\"network_name\":\"VM Network\",\"mac_address\":\"00:50:56:91:6d:1a\",\"nic_name\":\"Network adapter 1\"}],\"num_cpu\":2},{\"disks\":[{\"disk_file\":\"[datastore4-130-4TB-SATA] starling-vcenter-template/starling-vcenter-template.vmdk\",\"name\":\"Hard disk 1\",\"size\":209715200}],\"id\":\"vm-241\",\"memory_size_mb\":12288,\"name\":\"starling-vcenter-template\",\"nic_info\":[{\"network_name\":\"VM Network\",\"mac_address\":\"00:50:56:91:49:84\",\"nic_name\":\"Network adapter 1\"},{\"network_name\":\"VM Private\",\"mac_address\":\"00:50:56:91:8d:5e\",\"nic_name\":\"Network adapter 2\"}],\"num_cpu\":16},{\"disks\":[{\"disk_file\":\"[datastore3-130-4TB-SATA] saur-online-1/saur-online-1.vmdk\",\"name\":\"Hard disk 1\",\"size\":104857600},{\"disk_file\":\"[datastore3-130-4TB-SATA] saur-online-1/saur-online-1_1.vmdk\",\"name\":\"Hard disk 2\",\"size\":104857600},{\"disk_file\":\"[datastore3-130-4TB-SATA] saur-online-1/saur-online-1_2.vmdk\",\"name\":\"Hard disk 3\",\"size\":52428800}],\"id\":\"vm-353\",\"memory_size_mb\":8192,\"name\":\"saur-online-1\",\"nic_info\":[{\"network_name\":\"VM Network\",\"mac_address\":\"00:50:56:91:bb:9a\",\"nic_name\":\"Network adapter 1\"},{\"network_name\":\"VM Private\",\"mac_address\":\"00:50:56:91:39:53\",\"nic_name\":\"Network adapter 2\"}],\"num_cpu\":4},{\"disks\":[{\"disk_file\":\"[datastore3-130-4TB-SATA] RHEL_7.2_TEMPLATE/RHEL_7.2_TEMPLATE.vmdk\",\"name\":\"Hard disk 1\",\"size\":209715200}],\"id\":\"vm-604\",\"memory_size_mb\":8192,\"name\":\"RHEL_7.2_TEMPLATE\",\"nic_info\":[{\"network_name\":\"VM Private\",\"mac_address\":\"00:50:56:91:12:4e\",\"nic_name\":\"Network adapter 1\"}],\"num_cpu\":4},{\"disks\":[{\"disk_file\":\"[datastore3-130-4TB-SATA] template_redhat_7.3_Fresh/template_redhat_7.3_Fresh.vmdk\",\"name\":\"Hard disk 1\",\"size\":209715200}],\"id\":\"vm-693\",\"memory_size_mb\":8192,\"name\":\"template_redhat_7.3_Fresh\",\"nic_info\":[{\"network_name\":\"VM Private\",\"mac_address\":\"00:50:56:91:9a:ac\",\"nic_name\":\"Network adapter 1\"}],\"num_cpu\":2},{\"disks\":[{\"disk_file\":\"[datastore4-130-4TB-SATA] Deepali_Template_multidisk/Deepali_Template_multidisk.vmdk\",\"name\":\"Hard disk 1\",\"size\":157286400},{\"disk_file\":\"[datastore4-130-4TB-SATA] Deepali_Template_multidisk/Deepali_Template_multidisk_1.vmdk\",\"name\":\"Hard disk 2\",\"size\":102400000},{\"disk_file\":\"[datastore4-130-4TB-SATA] Deepali_Template_multidisk/Deepali_Template_multidisk_3.vmdk\",\"name\":\"Hard disk 3\",\"size\":10485760},{\"disk_file\":\"[datastore4-130-4TB-SATA] Deepali_Template_multidisk/Deepali_Template_multidisk_2.vmdk\",\"name\":\"Hard disk 4\",\"size\":10485760}],\"id\":\"vm-1246\",\"memory_size_mb\":4096,\"name\":\"Deepali_Template_multidisk\",\"nic_info\":[{\"network_name\":\"VM Network\",\"mac_address\":\"00:50:56:91:6d:1a\",\"nic_name\":\"Network adapter 1\"}],\"num_cpu\":2},{\"disks\":[{\"disk_file\":\"[datastore4-130-4TB-SATA] starling-vcenter-template/starling-vcenter-template.vmdk\",\"name\":\"Hard disk 1\",\"size\":209715200}],\"id\":\"vm-241\",\"memory_size_mb\":12288,\"name\":\"starling-vcenter-template\",\"nic_info\":[{\"network_name\":\"VM Network\",\"mac_address\":\"00:50:56:91:49:84\",\"nic_name\":\"Network adapter 1\"},{\"network_name\":\"VM Private\",\"mac_address\":\"00:50:56:91:8d:5e\",\"nic_name\":\"Network adapter 2\"}],\"num_cpu\":16},{\"disks\":[{\"disk_file\":\"[datastore3-130-4TB-SATA] saur-online-1/saur-online-1.vmdk\",\"name\":\"Hard disk 1\",\"size\":104857600},{\"disk_file\":\"[datastore3-130-4TB-SATA] saur-online-1/saur-online-1_1.vmdk\",\"name\":\"Hard disk 2\",\"size\":104857600},{\"disk_file\":\"[datastore3-130-4TB-SATA] saur-online-1/saur-online-1_2.vmdk\",\"name\":\"Hard disk 3\",\"size\":52428800}],\"id\":\"vm-353\",\"memory_size_mb\":8192,\"name\":\"saur-online-1\",\"nic_info\":[{\"network_name\":\"VM Network\",\"mac_address\":\"00:50:56:91:bb:9a\",\"nic_name\":\"Network adapter 1\"},{\"network_name\":\"VM Private\",\"mac_address\":\"00:50:56:91:39:53\",\"nic_name\":\"Network adapter 2\"}],\"num_cpu\":4},{\"disks\":[{\"disk_file\":\"[datastore3-130-4TB-SATA] RHEL_7.2_TEMPLATE/RHEL_7.2_TEMPLATE.vmdk\",\"name\":\"Hard disk 1\",\"size\":209715200}],\"id\":\"vm-604\",\"memory_size_mb\":8192,\"name\":\"RHEL_7.2_TEMPLATE\",\"nic_info\":[{\"network_name\":\"VM Private\",\"mac_address\":\"00:50:56:91:12:4e\",\"nic_name\":\"Network adapter 1\"}],\"num_cpu\":4},{\"disks\":[{\"disk_file\":\"[datastore3-130-4TB-SATA] template_redhat_7.3_Fresh/template_redhat_7.3_Fresh.vmdk\",\"name\":\"Hard disk 1\",\"size\":209715200}],\"id\":\"vm-693\",\"memory_size_mb\":8192,\"name\":\"template_redhat_7.3_Fresh\",\"nic_info\":[{\"network_name\":\"VM Private\",\"mac_address\":\"00:50:56:91:9a:ac\",\"nic_name\":\"Network adapter 1\"}],\"num_cpu\":2},{\"disks\":[{\"disk_file\":\"[iSCSI-SAN-Storage1] dh12-vm1-0-20171122135613/dh12-vm1-0-20171122135613.vmdk\",\"name\":\"Hard disk 1\",\"size\":51200000},{\"disk_file\":\"[iSCSI-SAN-Storage1] dh12-vm1-0-20171122135613/dh12-vm1-0-20171122135613_1.vmdk\",\"name\":\"Hard disk 2\",\"size\":102400000}],\"id\":\"vm-1228\",\"memory_size_mb\":4096,\"name\":\"dh12-vm1-0-20171122135613\",\"nic_info\":null,\"num_cpu\":2},{\"disks\":[{\"disk_file\":\"[datastore1-131-1TB-SSD] Template-RHEL73/Template-RHEL73_0.vmdk\",\"name\":\"Hard disk 1\",\"size\":52428800}],\"id\":\"vm-23\",\"memory_size_mb\":4096,\"name\":\"Template-RHEL73\",\"nic_info\":[{\"network_name\":\"VM Private\",\"mac_address\":\"00:0c:29:52:ed:4d\",\"nic_name\":\"Network adapter 1\"},{\"network_name\":\"VM Network\",\"mac_address\":\"00:0c:29:52:ed:57\",\"nic_name\":\"Network adapter 2\"}],\"num_cpu\":2},{\"disks\":[{\"disk_file\":\"[datastore4-131-4TB-SATA] CentOS73-Template-public-network/CentOS73-Template-public-network.vmdk\",\"name\":\"Hard disk 1\",\"size\":104857600}],\"id\":\"vm-38\",\"memory_size_mb\":4096,\"name\":\"CentOS73-Template-public-network\",\"nic_info\":[{\"network_name\":\"VM Network\",\"mac_address\":\"00:50:56:91:e4:57\",\"nic_name\":\"Network adapter 1\"},{\"network_name\":\"VM Private\",\"mac_address\":\"00:50:56:91:0b:ee\",\"nic_name\":\"Network adapter 2\"}],\"num_cpu\":2},{\"disks\":[{\"disk_file\":\"[datastore4-131-4TB-SATA] centos73-Template-public-private/centos73-Template-public-private.vmdk\",\"name\":\"Hard disk 1\",\"size\":104857600}],\"id\":\"vm-40\",\"memory_size_mb\":4096,\"name\":\"centos73-Template-public-private\",\"nic_info\":[{\"network_name\":\"VM Network\",\"mac_address\":\"00:50:56:91:0c:f0\",\"nic_name\":\"Network adapter 1\"},{\"network_name\":\"VM Private\",\"mac_address\":\"00:50:56:91:16:31\",\"nic_name\":\"Network adapter 2\"}],\"num_cpu\":2},{\"disks\":[{\"disk_file\":\"[datastore3-131-4TB-SATA] Template-win/Template-win.vmdk\",\"name\":\"Hard disk 1\",\"size\":10485760}],\"id\":\"vm-403\",\"memory_size_mb\":4096,\"name\":\"Template-win\",\"nic_info\":[{\"network_name\":\"VM Private\",\"mac_address\":\"00:50:56:91:ce:3a\",\"nic_name\":\"Network adapter 1\"}],\"num_cpu\":1},{\"disks\":[{\"disk_file\":\"[datastore3-131-4TB-SATA] visor_template_2.1/visor_template_2.1.vmdk\",\"name\":\"Hard disk 1\",\"size\":51200000},{\"disk_file\":\"[datastore3-131-4TB-SATA] visor_template_2.1/visor_template_2.1_1.vmdk\",\"name\":\"Hard disk 2\",\"size\":102400000}],\"id\":\"vm-418\",\"memory_size_mb\":4096,\"name\":\"visor_template_2.1\",\"nic_info\":[{\"network_name\":\"VM Network\",\"mac_address\":\"00:50:56:91:a2:b4\",\"nic_name\":\"Network adapter 1\"}],\"num_cpu\":2},{\"disks\":[{\"disk_file\":\"[datastore4-131-4TB-SATA] Ankit-template/Ankit-template.vmdk\",\"name\":\"Hard disk 1\",\"size\":104857600},{\"disk_file\":\"[datastore4-131-4TB-SATA] Ankit-template/Ankit-template_1.vmdk\",\"name\":\"Hard disk 2\",\"size\":209715200},{\"disk_file\":\"[datastore4-131-4TB-SATA] Ankit-template/Ankit-template_2.vmdk\",\"name\":\"Hard disk 3\",\"size\":104857600}],\"id\":\"vm-463\",\"memory_size_mb\":8192,\"name\":\"Ankit-template\",\"nic_info\":[{\"network_name\":\"VM Network\",\"mac_address\":\"00:50:56:91:93:ba\",\"nic_name\":\"Network adapter 1\"},{\"network_name\":\"VM Private\",\"mac_address\":\"00:50:56:91:f0:f8\",\"nic_name\":\"Network adapter 2\"}],\"num_cpu\":4}]","id":"app:8:deploy","progress":100}

2017/12/02 09:20:48 Breaking..
