### PR TITLE
MRPHS-3934: When we select the vm template from vcentre than no of n/w's present in vcentre should not be ignored

### DIFF
--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -740,8 +740,6 @@ func getNicInfo(vmMo mo.VirtualMachine) []VirtualEthernetCard {
 			switch b := nwcard.Backing.(type) {
 			case *types.VirtualEthernetCardNetworkBackingInfo:
 				nic.NetworkName = b.DeviceName
-			default:
-				continue
 			}
 			nicInfo = append(nicInfo, nic)
 		}

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -737,10 +737,6 @@ func getNicInfo(vmMo mo.VirtualMachine) []VirtualEthernetCard {
 			nwcard := c.GetVirtualEthernetCard()
 			nic.MacAddress = nwcard.MacAddress
 			nic.NicName = nwcard.DeviceInfo.GetDescription().Label
-			switch b := nwcard.Backing.(type) {
-			case *types.VirtualEthernetCardNetworkBackingInfo:
-				nic.NetworkName = b.DeviceName
-			}
 			nicInfo = append(nicInfo, nic)
 		}
 	}


### PR DESCRIPTION
**Jira-id**

MRPHS-3934

**Problem**

When we select the vm template from vcentre than no of n/w's present in vcentre should not be ignored

**Solution**

Adding the nic info for other backing types also to the nic info.

**Unit Testing**

Tried creating vm app template from a template(visor_template_2.1) having distributed port group. The nic info is fetched. Logs are attached below:

[c3ntry.txt](https://github.com/apporbit/libretto/files/1542644/c3ntry.txt)

The apporbit ui shows two entries for nics, as expected.
