### PR TITLE
MRPHS-4082: Return success in vm destroy if vm does not exist

### DIFF
--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -804,6 +804,19 @@ func (vm *VM) Destroy() (err error) {
 	}
 	defer vm.cancel()
 
+	// Get a reference to the datacenter with host and vm folders populated
+	dcMo, err := GetDatacenter(vm)
+	if err != nil {
+		return err
+	}
+	exists, err := Exists(vm, dcMo, vm.Name)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+
 	state, err := getState(vm)
 	if err != nil {
 		return err
@@ -861,11 +874,6 @@ func (vm *VM) Destroy() (err error) {
 		}
 	}
 
-	// Get a reference to the datacenter with host and vm folders populated
-	dcMo, err := GetDatacenter(vm)
-	if err != nil {
-		return err
-	}
 	vmMo, err := findVM(vm, dcMo, vm.Name)
 	if err != nil {
 		return err


### PR DESCRIPTION
**Jira-id**

MRPHS-4082

**Problem**

When we are deleting the failed app and it gets deleted from UI but error message we get is delete operation failed

**Solution**

Return success in vm destroy if vm does not exist.

**Testing**

in progress.