### PR TITLE
MRPHS-4183: Support fetching all VMs in a VCenter along with key details

### DIFF
--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -758,25 +758,13 @@ func getNicInfo(vmMo mo.VirtualMachine) []VirtualEthernetCard {
 	return nicInfo
 }
 
-// GetIPsAndId returns the IPs and reference Id of this VM. Returns all the IPs known to the API for
-// the different network cards for this VM. Includes IPV4 and IPV6 addresses.
-func (vm *VM) GetIPsAndId() ([]net.IP, string, error) {
-	if err := SetupSession(vm); err != nil {
-		return nil, "", err
-	}
-	defer vm.cancel()
-
-	// Get a reference to the datacenter with host and vm folders populated
-	dcMo, err := GetDatacenter(vm)
-	if err != nil {
-		return nil, "", err
-	}
-	vmMo, err := findVM(vm, dcMo, vm.Name)
-	if err != nil {
-		return nil, "", err
-	}
+// getIpFromVmMo: gets ip from vm managed object
+func getIpFromVmMo(vmMo *mo.VirtualMachine) []net.IP {
 	// Lazy initialized when there is an IP address later.
 	var ips []net.IP
+	if vmMo.Guest == nil {
+		return ips
+	}
 	for _, nic := range vmMo.Guest.Net {
 		for _, ip := range nic.IpAddress {
 			netIP := net.ParseIP(ip)
@@ -795,6 +783,27 @@ func (vm *VM) GetIPsAndId() ([]net.IP, string, error) {
 			ips = append(ips, ip)
 		}
 	}
+	return ips
+}
+
+// GetIPsAndId returns the IPs and reference Id of this VM. Returns all the IPs known to the API for
+// the different network cards for this VM. Includes IPV4 and IPV6 addresses.
+func (vm *VM) GetIPsAndId() ([]net.IP, string, error) {
+	if err := SetupSession(vm); err != nil {
+		return nil, "", err
+	}
+	defer vm.cancel()
+
+	// Get a reference to the datacenter with host and vm folders populated
+	dcMo, err := GetDatacenter(vm)
+	if err != nil {
+		return nil, "", err
+	}
+	vmMo, err := findVM(vm, dcMo, vm.Name)
+	if err != nil {
+		return nil, "", err
+	}
+	ips := getIpFromVmMo(vmMo)
 	return ips, vmMo.Self.Value, nil
 }
 
@@ -1490,7 +1499,8 @@ func getVmsInFolder(vm *VM, folder *object.Folder, path string) (
 			// mo of the vm
 			vmMo := mo.VirtualMachine{}
 			err := vm.collector.RetrieveOne(vm.ctx, mor, []string{
-				"name", "config", "runtime", "summary"}, &vmMo)
+				"name", "guest", "config", "runtime",
+				"summary"}, &vmMo)
 			if err != nil {
 				if isObjectDeleted(err) {
 					continue
@@ -1678,8 +1688,66 @@ func CreateTemplate(vm *VM) error {
 	return err
 }
 
-// GetTemplateList : Returns the template VMs in a cluster
-func GetTemplateList(vm *VM) ([]map[string]interface{}, error) {
+// getOsDetails: returns details of guest os
+func getOsDetails(vmMo mo.VirtualMachine) map[string]interface{} {
+	osDetails := make(map[string]interface{})
+	if vmMo.Guest == nil {
+		return osDetails
+	}
+	osDetails = map[string]interface{}{
+		"guest_id":        vmMo.Guest.GuestId,
+		"guest_family":    vmMo.Guest.GuestFamily,
+		"guest_full_name": vmMo.Guest.GuestFullName,
+		"hostname":        vmMo.Guest.HostName,
+	}
+	return osDetails
+}
+
+// getVmInfo : get vm info from vm managed object
+func getVmInfo(vmMo mo.VirtualMachine, vmPath string) map[string]interface{} {
+	var (
+		toolsStatus bool
+	)
+	// fetching fisk info
+	diskInfo := make([]map[string]interface{}, 0)
+	for _, device := range vmMo.Config.Hardware.Device {
+		disk, ok := device.(*types.VirtualDisk)
+		if !ok {
+			continue
+		}
+		devinfo, ok := disk.DeviceInfo.(*types.Description)
+		if !ok {
+			continue
+		}
+		backing := disk.Backing.(types.BaseVirtualDeviceFileBackingInfo)
+		fileBackingInfo := backing.GetVirtualDeviceFileBackingInfo()
+		diskInfo = append(diskInfo, map[string]interface{}{
+			"name":      devinfo.Label,
+			"size":      disk.CapacityInKB,
+			"disk_file": fileBackingInfo.FileName,
+		})
+	}
+	if vmMo.Guest != nil {
+		toolsStatus = getToolsRunningStatus(
+			vmMo.Guest.ToolsRunningStatus)
+	}
+
+	return map[string]interface{}{
+		"name":           vmPath, // full name/path of vm
+		"id":             vmMo.Self.Value,
+		"instance_uuid":  vmMo.Summary.Config.InstanceUuid,
+		"memory_size_mb": vmMo.Summary.Config.MemorySizeMB,
+		"num_cpu":        vmMo.Summary.Config.NumCpu,
+		"disks":          diskInfo,
+		"ip_addresses":   getIpFromVmMo(&vmMo),
+		"nic_info":       getNicInfo(vmMo),
+		"os_details":     getOsDetails(vmMo),
+		"tool_status":    toolsStatus,
+	}
+}
+
+// GetVmList : Returns the VMs/templates info in a dc/cluster/host
+func GetVmList(vm *VM, template bool) ([]map[string]interface{}, error) {
 	vmList := make([]map[string]interface{}, 0)
 	vmMoList, err := getVirtualMachines(vm)
 	if err != nil {
@@ -1691,36 +1759,17 @@ func GetTemplateList(vm *VM) ([]map[string]interface{}, error) {
 	}
 	for name, vmo := range vmMoList {
 		// Filter out the templates
-		if vmo.Config == nil || !vmo.Config.Template {
+		if vmo.Config == nil {
 			continue
 		}
-		// fetching fisk info
-		diskInfo := make([]map[string]interface{}, 0)
-		for _, device := range vmo.Config.Hardware.Device {
-			disk, ok := device.(*types.VirtualDisk)
-			if !ok {
-				continue
-			}
-			devinfo, ok := disk.DeviceInfo.(*types.Description)
-			if !ok {
-				continue
-			}
-			backing := disk.Backing
-			fileBackingInfo := backing.(types.BaseVirtualDeviceFileBackingInfo).GetVirtualDeviceFileBackingInfo()
-			diskInfo = append(diskInfo, map[string]interface{}{
-				"name":      devinfo.Label,
-				"size":      disk.CapacityInKB,
-				"disk_file": fileBackingInfo.FileName,
-			})
+		// if asked for template and object is not template or
+		// if asked for vm and object is a template then skip object
+		if template && !vmo.Config.Template ||
+			!template && vmo.Config.Template {
+			continue
 		}
-		vmList = append(vmList, map[string]interface{}{
-			"name":           name, // full name/path of vm
-			"id":             vmo.Self.Value,
-			"disks":          diskInfo,
-			"nic_info":       getNicInfo(vmo),
-			"memory_size_mb": vmo.Summary.Config.MemorySizeMB,
-			"num_cpu":        vmo.Summary.Config.NumCpu,
-		})
+		vminfo := getVmInfo(vmo, name)
+		vmList = append(vmList, vminfo)
 	}
 	return vmList, nil
 }


### PR DESCRIPTION
**Jira-id**

MRPHS-4183

**Problem**

Support fetching all VMs in a VCenter along with key details is needed

**Solution**

Added support for fetching all the vms in datacenter.

**Unit-testing**

Done. Tried fetching vm details with uuids and without uuids. The vm details are fetched. Logs attached below:

[c3ntry.txt](https://github.com/apporbit/libretto/files/1571415/c3ntry.txt)
