### PR TITLE
MRPHS-4239, MRPHS-4224: VM Templates are not getting returned from c3ntry ,Issue with delete VM

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -27,7 +27,6 @@ import (
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
-	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 
 	"github.com/apcera/libretto/util"
@@ -467,10 +466,7 @@ func searchTree(vm *VM, mor *types.ManagedObjectReference, name string) (
 				err = vm.collector.RetrieveOne(vm.ctx, child,
 					[]string{"name"}, &childMo)
 				if err != nil {
-					if soap.IsSoapFault(err) {
-						continue
-					}
-					return nil, err
+					continue
 				}
 
 				// unescaping to convert any escaped character
@@ -498,11 +494,7 @@ func searchTree(vm *VM, mor *types.ManagedObjectReference, name string) (
 						"snapshot.currentSnapshot",
 						"summary", "runtime"}, &vmMo)
 				if err != nil {
-					if soap.IsSoapFault(err) {
-						continue
-					}
-					return nil, NewErrorObjectNotFound(
-						err, name)
+					continue
 				}
 				// unescaping to convert any escaped character
 				vmName, err := url.QueryUnescape(vmMo.Name)

--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -27,6 +27,7 @@ import (
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 
 	"github.com/apcera/libretto/util"
@@ -466,6 +467,9 @@ func searchTree(vm *VM, mor *types.ManagedObjectReference, name string) (
 				err = vm.collector.RetrieveOne(vm.ctx, child,
 					[]string{"name"}, &childMo)
 				if err != nil {
+					if soap.IsSoapFault(err) {
+						continue
+					}
 					return nil, err
 				}
 
@@ -494,10 +498,11 @@ func searchTree(vm *VM, mor *types.ManagedObjectReference, name string) (
 						"snapshot.currentSnapshot",
 						"summary", "runtime"}, &vmMo)
 				if err != nil {
+					if soap.IsSoapFault(err) {
+						continue
+					}
 					return nil, NewErrorObjectNotFound(
-						errors.New(
-							"could not find vm"),
-						name)
+						err, name)
 				}
 				// unescaping to convert any escaped character
 				vmName, err := url.QueryUnescape(vmMo.Name)

--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -466,7 +466,10 @@ func searchTree(vm *VM, mor *types.ManagedObjectReference, name string) (
 				err = vm.collector.RetrieveOne(vm.ctx, child,
 					[]string{"name"}, &childMo)
 				if err != nil {
-					continue
+					if isManagedObjectNotFoundError(err) {
+						continue
+					}
+					return nil, err
 				}
 
 				// unescaping to convert any escaped character
@@ -494,7 +497,10 @@ func searchTree(vm *VM, mor *types.ManagedObjectReference, name string) (
 						"snapshot.currentSnapshot",
 						"summary", "runtime"}, &vmMo)
 				if err != nil {
-					continue
+					if isManagedObjectNotFoundError(err) {
+						continue
+					}
+					return nil, err
 				}
 				// unescaping to convert any escaped character
 				vmName, err := url.QueryUnescape(vmMo.Name)

--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -466,7 +466,7 @@ func searchTree(vm *VM, mor *types.ManagedObjectReference, name string) (
 				err = vm.collector.RetrieveOne(vm.ctx, child,
 					[]string{"name"}, &childMo)
 				if err != nil {
-					if isManagedObjectNotFoundError(err) {
+					if isObjectDeleted(err) {
 						continue
 					}
 					return nil, err
@@ -497,7 +497,7 @@ func searchTree(vm *VM, mor *types.ManagedObjectReference, name string) (
 						"snapshot.currentSnapshot",
 						"summary", "runtime"}, &vmMo)
 				if err != nil {
-					if isManagedObjectNotFoundError(err) {
+					if isObjectDeleted(err) {
 						continue
 					}
 					return nil, err

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -24,7 +24,6 @@ import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25/mo"
-	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -1444,10 +1443,7 @@ func getVmsInFolder(vm *VM, folder *object.Folder, path string) (
 			err := vm.collector.RetrieveOne(vm.ctx, mor, []string{
 				"name"}, &folderMo)
 			if err != nil {
-				if soap.IsSoapFault(err) {
-					continue
-				}
-				return nil, err
+				continue
 			}
 			// unescaping to convert any escaped character
 			folderName, err := url.QueryUnescape(folderMo.Name)
@@ -1476,10 +1472,7 @@ func getVmsInFolder(vm *VM, folder *object.Folder, path string) (
 			err := vm.collector.RetrieveOne(vm.ctx, mor, []string{
 				"name", "config", "runtime", "summary"}, &vmMo)
 			if err != nil {
-				if soap.IsSoapFault(err) {
-					continue
-				}
-				return nil, err
+				continue
 			}
 			// unescaping to convert any escaped character
 			vmName, err := url.QueryUnescape(vmMo.Name)

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -399,7 +399,7 @@ func isObjectOfType(object interface{}, objectType string) bool {
 	return false
 }
 
-func isManagedObjectNotFoundError(err error) bool {
+func isObjectDeleted(err error) bool {
 	fault := soap.ToSoapFault(err).Detail.Fault
 	return isObjectOfType(fault, "ManagedObjectNotFound")
 }
@@ -1460,7 +1460,7 @@ func getVmsInFolder(vm *VM, folder *object.Folder, path string) (
 			err := vm.collector.RetrieveOne(vm.ctx, mor, []string{
 				"name"}, &folderMo)
 			if err != nil {
-				if isManagedObjectNotFoundError(err) {
+				if isObjectDeleted(err) {
 					continue
 				}
 				return nil, err
@@ -1492,7 +1492,7 @@ func getVmsInFolder(vm *VM, folder *object.Folder, path string) (
 			err := vm.collector.RetrieveOne(vm.ctx, mor, []string{
 				"name", "config", "runtime", "summary"}, &vmMo)
 			if err != nil {
-				if isManagedObjectNotFoundError(err) {
+				if isObjectDeleted(err) {
 					continue
 				}
 				return nil, err

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -24,6 +24,7 @@ import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -1443,6 +1444,9 @@ func getVmsInFolder(vm *VM, folder *object.Folder, path string) (
 			err := vm.collector.RetrieveOne(vm.ctx, mor, []string{
 				"name"}, &folderMo)
 			if err != nil {
+				if soap.IsSoapFault(err) {
+					continue
+				}
 				return nil, err
 			}
 			// unescaping to convert any escaped character
@@ -1472,6 +1476,9 @@ func getVmsInFolder(vm *VM, folder *object.Folder, path string) (
 			err := vm.collector.RetrieveOne(vm.ctx, mor, []string{
 				"name", "config", "runtime", "summary"}, &vmMo)
 			if err != nil {
+				if soap.IsSoapFault(err) {
+					continue
+				}
 				return nil, err
 			}
 			// unescaping to convert any escaped character
@@ -1668,7 +1675,7 @@ func GetTemplateList(vm *VM) ([]map[string]interface{}, error) {
 	}
 	for name, vmo := range vmMoList {
 		// Filter out the templates
-		if vmo.Config != nil && !vmo.Config.Template {
+		if vmo.Config == nil || !vmo.Config.Template {
 			continue
 		}
 		// fetching fisk info


### PR DESCRIPTION
**Jira-Id**

MRPHS-4239
MRPHS-4224

**Problem**

VM Templates are not getting returned from c3ntry. Invalid check for vmo.Config.
Issue with delete VM, multiple delete vm fails as it fails to fetches information of the vms deleted during vm discovery (soap fault error).

**Resolution**

Corrected check for vmo.Config in get Template list. Skips if retrieving information for a vm returns soapfaulterror.

**Testing**

Done. Tried deploying 10 vms (replica count = 10), performed restart, stop and delete operation on the app. The app restarted, stopped and deleted successfully. Logs below:

[c3ntry.txt](https://github.com/apporbit/libretto/files/1562738/c3ntry.txt)
