### PR TITLE
MRPHS-4384 : Create visor call is failing in c3ntry

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -824,11 +824,13 @@ var cloneFromTemplate = func(vm *VM, dcMo *mo.Datacenter, usableDatastores []str
 	}
 	config.DeviceChange = deviceChangeSpec
 
-	// Resize (increase)/delete existing volumes in VM template
-	conf, err := resizeAndDeleteVols(*vmMo, vm.FixedDisks)
-	config.DeviceChange = append(config.DeviceChange, conf...)
-	if err != nil {
-		return err
+	if len(vm.FixedDisks) != 0 {
+		// Resize (increase)/delete existing volumes in VM template
+		conf, err := resizeAndDeleteVols(*vmMo, vm.FixedDisks)
+		if err != nil {
+			return err
+		}
+		config.DeviceChange = append(config.DeviceChange, conf...)
 	}
 
 	err = checkAndCreateCustomSpec(vm)


### PR DESCRIPTION
**Jira-ID**

MRPHS-4384

**Problem**

Create visor call is failing in c3ntry. The template vm created, does not have the root disk as the fixed disk is not present and the hence the vm is not booted up.

**Resolution**

Resizing of disks is done only if the fixed disk is not empty. If fixed_disk is empty, all the disks in the template are assigned as is.

**Unit Testing**

Done. Logs below:

```
[root@my_machine example]# go run c3ntry_client.go
Sending request:
action:"create_visor" args:"{\"Insecure\":true,\"cloud_type\":\"vsphere\",\"type\":\"PUBLIC\",\"Host\":\"209.205.216.11\",\"Username\":\"developer@vsphere.local\",\"Password\":\"Orbit_DEv_vCP1\",\"Datacenter\":\"C3 DataCenter\",\"Destination\":{\"DestinationName\":\"C3 Cluster-1\",\"DestinationType\":\"cluster\",\"HostSystem\":\"67.220.186.4\"},\"size\":\"medium\",\"Datastores\":[\"datastore2-ESXi13-2TB\"],\"OvaPathUrl\":\"http://67.220.182.204:81/fork/apporbit-visor-2.1.ova\",\"network\":{\"networks\":[{\"name\":\"VM Network\",\"description\":\"VM Network\"}]},\"vm_template\":{\"name\":\"centos-7.3\",\"user\":\"root\",\"password\":\"$Dogreat12\"}}" id:"visor:1:vm:1:create"

2018/01/02 01:16:42 Received Response:
result:"Successfully created visor template" id:"visor:1:vm:1:create" progress:100

2018/01/02 01:16:42 Response String:
{"result":"Successfully created visor template","id":"visor:1:vm:1:create","progress":100}

2018/01/02 01:16:42 Breaking..
[root@my_machine example]#
```

[c3ntry.txt](https://github.com/apporbit/libretto/files/1596935/c3ntry.txt)