### PR TITLE
MRPHS-3917: Libretto changes for adding support for Multi-VM operation in Halo for Vsphere

### DIFF
--- a/virtualmachine/virtualmachine.go
+++ b/virtualmachine/virtualmachine.go
@@ -24,7 +24,7 @@ type VirtualMachine interface {
 	GetSSH(ssh.Options) (ssh.Client, error)
 }
 
-type NetworkSettings struct {
+type NetworkSetting struct {
 	Ip         string `json:"ip_address"`
 	Gateway    string `json:"default_gateway"`
 	SubnetMask string `json:"subnet_mask"`

--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -1693,7 +1693,7 @@ func createCustomSpecStaticIp(vm *VM) error {
 func updateCustomSpec(vm *VM, tempMo *mo.VirtualMachine,
 	customSpec *types.CustomizationSpec) *types.CustomizationSpec {
 	// if ip or subnet is not passed return nil
-	if vm.NetworkSettings.Ip == "" || vm.NetworkSettings.SubnetMask == "" {
+	if vm.NetworkSetting.Ip == "" || vm.NetworkSetting.SubnetMask == "" {
 		return nil
 	}
 	// set ip address, subnet mask, default gateway
@@ -1702,15 +1702,15 @@ func updateCustomSpec(vm *VM, tempMo *mo.VirtualMachine,
 	ipValue := reflect.ValueOf(ip).Elem()
 	ipAddress := ipValue.FieldByName("IpAddress")
 	if ipAddress.CanSet() || ipAddress.IsValid() {
-		ipAddress.SetString(vm.NetworkSettings.Ip)
+		ipAddress.SetString(vm.NetworkSetting.Ip)
 	}
-	nicSetting.Adapter.SubnetMask = vm.NetworkSettings.SubnetMask
-	gateway := vm.NetworkSettings.Gateway
+	nicSetting.Adapter.SubnetMask = vm.NetworkSetting.SubnetMask
+	gateway := vm.NetworkSetting.Gateway
 	nicSetting.Adapter.Gateway = append(nicSetting.Adapter.Gateway, gateway)
 
 	// set dns server
-	if vm.NetworkSettings.DnsServer != "" {
-		dnsServerList := []string{vm.NetworkSettings.DnsServer}
+	if vm.NetworkSetting.DnsServer != "" {
+		dnsServerList := []string{vm.NetworkSetting.DnsServer}
 		for _, ip := range tempMo.Guest.IpStack {
 			dnsServerList = append(dnsServerList,
 				ip.DnsConfig.IpAddress...)
@@ -1735,7 +1735,7 @@ func IsClusterDrsEnabled(vm *VM) (bool, error) {
 		return false, err
 	}
 
-	drsEnabled := crMo.Configuration.DrsConfig.Enabled
+	drsEnabled := crMo.Configuration.DrsConfig.Enaearled
 	if drsEnabled != nil {
 		return *drsEnabled, nil
 	}

--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -1735,7 +1735,7 @@ func IsClusterDrsEnabled(vm *VM) (bool, error) {
 		return false, err
 	}
 
-	drsEnabled := crMo.Configuration.DrsConfig.Enaearled
+	drsEnabled := crMo.Configuration.DrsConfig.Enabled
 	if drsEnabled != nil {
 		return *drsEnabled, nil
 	}

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -37,6 +37,16 @@ const (
 	SKIPTEMPLATE_ERROR = iota
 	SKIPTEMPLATE_OVERWRITE
 	SKIPTEMPLATE_USE
+
+	// Constants for supproted values for Flavor:Name
+	FlavorSmall   = "small"
+	FlavorMedium  = "medium"
+	FlavorLarge   = "large"
+	FlavorXLarge  = "xlarge"
+	Flavor2XLarge = "2xlarge"
+	Flavor4XLarge = "4xlarge"
+	Flavor8XLarge = "8xlarge"
+	FlavorCustom  = "custom"
 )
 
 type vmwareFinder struct {
@@ -501,6 +511,9 @@ type VMInfo struct {
 }
 
 type Flavor struct {
+	// Flavor name. Supported values are defined as
+	// constants [FlavorLarge, FlavorSmall, FlavorMedium, FlavorCustom]
+	Name string
 	// Represents the number of CPUs
 	NumCPUs int32
 	// Represents the size of main memory in MB
@@ -546,7 +559,7 @@ type VM struct {
 	// the datastores that were passed in.
 	UseLocalTemplates bool
 	// SkipExisting when set to '2' lets Provision succeed even if the VM already exists.
-	SkipExisting int
+	SkipExisting *int
 	// Credentials are the credentials to use when connecting to the VM over SSH
 	Credentials ssh.Credentials
 	// FixedDisks is a slice of existing disks which user wants to either expand/delete from VM
@@ -562,15 +575,15 @@ type VM struct {
 	// linked clones.
 	UseLinkedClones bool
 	// Skip waiting for IP to be assigned to VM in create/start actions
-	SkipIPWait      bool
-	uri             *url.URL
-	ctx             context.Context
-	cancel          context.CancelFunc
-	client          *govmomi.Client
-	finder          finder
-	collector       collector
-	datastore       string
-	NetworkSettings lvm.NetworkSettings
+	SkipIPWait     bool
+	uri            *url.URL
+	ctx            context.Context
+	cancel         context.CancelFunc
+	client         *govmomi.Client
+	finder         finder
+	collector      collector
+	datastore      string
+	NetworkSetting lvm.NetworkSetting
 }
 
 // Provision provisions this VM.
@@ -610,7 +623,7 @@ func (vm *VM) Provision() (err error) {
 
 		// If it does exist, return an error if the skip existing is set to 0/SKIPTEMPLATE_ERROR
 		if e {
-			switch vm.SkipExisting {
+			switch *vm.SkipExisting {
 			case SKIPTEMPLATE_USE: //PASS
 			case SKIPTEMPLATE_ERROR:
 				return fmt.Errorf("Template already exists: %s", vm.Template)

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -798,31 +798,33 @@ func getIpFromVmMo(vmMo *mo.VirtualMachine) []net.IP {
 	return ips
 }
 
-// GetIPsAndId returns the IPs and reference Id of this VM. Returns all the IPs known to the API for
-// the different network cards for this VM. Includes IPV4 and IPV6 addresses.
-func (vm *VM) GetIPsAndId() ([]net.IP, string, error) {
+// GetIPsAndIds returns the IPs, reference Id and instance uuid of this VM.
+// Returns all the IPs known to the API for the different network cards
+// for this VM. Includes IPV4 and IPV6 addresses.
+func (vm *VM) GetIPsAndIds() ([]net.IP, string, string, error) {
 	if err := SetupSession(vm); err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
 	defer vm.cancel()
 
 	// Get a reference to the datacenter with host and vm folders populated
 	dcMo, err := GetDatacenter(vm)
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
 	vmMo, err := findVM(vm, dcMo, vm.Name)
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
 	ips := getIpFromVmMo(vmMo)
-	return ips, vmMo.Self.Value, nil
+
+	return ips, vmMo.Self.Value, vmMo.Summary.Config.InstanceUuid, nil
 }
 
 // GetIPs returns the IPs of this VM. Returns all the IPs known to the API for
 // the different network cards for this VM. Includes IPV4 and IPV6 addresses.
 func (vm *VM) GetIPs() ([]net.IP, error) {
-	ips, _, err := vm.GetIPsAndId()
+	ips, _, _, err := vm.GetIPsAndIds()
 	return ips, err
 }
 
@@ -989,7 +991,7 @@ func (vm *VM) GetVMInfo() (VMInfo, error) {
 		return vmInfo, err
 	}
 
-	ips, vmid, err := vm.GetIPsAndId()
+	ips, vmid, _, err := vm.GetIPsAndIds()
 	toolsRunningStatus := getToolsRunningStatus(vmMo.Guest.ToolsRunningStatus)
 
 	vmInfo.VMId = vmid

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -498,6 +498,7 @@ type VirtualEthernetCard struct {
 
 type VMInfo struct {
 	VMId               string
+	InstanceId         string
 	IpAddress          []net.IP
 	ToolsRunningStatus bool
 	OverallCpuUsage    int64
@@ -623,6 +624,9 @@ func (vm *VM) Provision() (err error) {
 
 		// If it does exist, return an error if the skip existing is set to 0/SKIPTEMPLATE_ERROR
 		if e {
+			if vm.SkipExisting == nil {
+				return fmt.Errorf("Mandatory parameter SkipExising not given")
+			}
 			switch *vm.SkipExisting {
 			case SKIPTEMPLATE_USE: //PASS
 			case SKIPTEMPLATE_ERROR:
@@ -801,31 +805,37 @@ func getIpFromVmMo(vmMo *mo.VirtualMachine) []net.IP {
 // GetIPsAndIds returns the IPs, reference Id and instance uuid of this VM.
 // Returns all the IPs known to the API for the different network cards
 // for this VM. Includes IPV4 and IPV6 addresses.
-func (vm *VM) GetIPsAndIds() ([]net.IP, string, string, error) {
+func (vm *VM) GetIPsAndIds() (VMInfo, error) {
+	var vmInfo VMInfo
 	if err := SetupSession(vm); err != nil {
-		return nil, "", "", err
+		return vmInfo, err
 	}
 	defer vm.cancel()
 
 	// Get a reference to the datacenter with host and vm folders populated
 	dcMo, err := GetDatacenter(vm)
 	if err != nil {
-		return nil, "", "", err
+		return vmInfo, err
 	}
 	vmMo, err := findVM(vm, dcMo, vm.Name)
 	if err != nil {
-		return nil, "", "", err
+		return vmInfo, err
 	}
 	ips := getIpFromVmMo(vmMo)
 
-	return ips, vmMo.Self.Value, vmMo.Summary.Config.InstanceUuid, nil
+	vmInfo = VMInfo{
+		VMId:       vmMo.Self.Value,
+		InstanceId: vmMo.Summary.Config.InstanceUuid,
+		IpAddress:  ips,
+	}
+	return vmInfo, nil
 }
 
 // GetIPs returns the IPs of this VM. Returns all the IPs known to the API for
 // the different network cards for this VM. Includes IPV4 and IPV6 addresses.
 func (vm *VM) GetIPs() ([]net.IP, error) {
-	ips, _, _, err := vm.GetIPsAndIds()
-	return ips, err
+	vmInfo, err := vm.GetIPsAndIds()
+	return vmInfo.IpAddress, err
 }
 
 // Destroy deletes this VM from vSphere.
@@ -991,11 +1001,9 @@ func (vm *VM) GetVMInfo() (VMInfo, error) {
 		return vmInfo, err
 	}
 
-	ips, vmid, _, err := vm.GetIPsAndIds()
+	vmInfo, err := vm.GetIPsAndIds()
 	toolsRunningStatus := getToolsRunningStatus(vmMo.Guest.ToolsRunningStatus)
 
-	vmInfo.VMId = vmid
-	vmInfo.IpAddress = ips
 	vmInfo.ToolsRunningStatus = toolsRunningStatus
 	vmInfo.OverallCpuUsage = int64(vmMo.Summary.QuickStats.OverallCpuUsage)
 	vmInfo.GuestMemoryUsage = int64(vmMo.Summary.QuickStats.GuestMemoryUsage)


### PR DESCRIPTION
**Jira Id**

[MRPHS-3917](https://apporbit.atlassian.net/browse/MRPHS-3917)

**Problem**

To support multi-vm operations through Halo some structs and parameters needs to changed.

**Resolution**

Three changes have been done:

1. SkipExisting parameter type has been changed from int to *int. Because, now request will be directly unmarshaled into struct, it needs to be checked if actually this parameter was in request or not else we need to set default value for this.

2. Flavor struct is modified to include Name. This is done so that all related to Flavor whether its name or configuration in terms of CPUs and Memory can be received in single unit.

3. NetworkSettings is changed to NetworkSetting because for single vm its appropriate to name it NetworkSetting as it represents single settings and then we can use NetworkSettings name for group of vms in request.

**Testing**

Unit tested all the multi-vm operations with dummy client. Logs attached.
[c3.log](https://github.com/apporbit/libretto/files/1520627/c3.log)

**Note:**
This change will require change in Halo and Appos(C3ntry).
PR for Halo: [MRPHS-3917](https://github.com/apporbit/halo/pull/65)
PR for Appos(C3ntry):  [MRPHS-3920](https://github.com/apporbit/appos/pull/281)
  