### PR TITLE
MRPSH-3919: Renamed GetTemplateList to GetImageList and removed GetDcImageList

### DIFF
--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -1421,40 +1421,6 @@ func GetClusterNetworkList(vm *VM, filter map[string][]string) ([]map[string]str
 	return networks, nil
 }
 
-// GetDcImageList : GetDcImageList returns the list of images in
-// all the datacenters in vcenter server
-func GetDcImageList(vm *VM) (map[string][]string, error) {
-	imageList := map[string][]string{}
-	// set up session to vcenter server
-	if err := SetupSession(vm); err != nil {
-		return nil, err
-	}
-	// get datacenter list in the vcenter server
-	dcList, err := vm.finder.DatacenterList(vm.ctx, "*")
-	if err != nil {
-		return nil, err
-	}
-
-	// for all datacenters in the vcenter server
-	for _, dc := range dcList {
-		allVmsMo, err := getDcVMList(vm, dc)
-		if err != nil {
-			return nil, err
-		}
-		if allVmsMo == nil {
-			continue
-		}
-		// generate response for the images in datacenter. In the response map
-		// the key is the datacenter name and value is the list of images in datacenter
-		for _, vmMo := range allVmsMo {
-			if vmMo.Config != nil && vmMo.Config.Template {
-				imageList[dc.Name()] = append(imageList[dc.Name()], vmMo.Name)
-			}
-		}
-	}
-	return imageList, nil
-}
-
 // getDcVMList : returns list of VirtualMachine objects in a Datacenter
 func getDcVMList(vm *VM, datacenter *object.Datacenter) (
 	map[string]mo.VirtualMachine, error) {


### PR DESCRIPTION
**Jira Id**

[MRPHS-3919](https://apporbit.atlassian.net/browse/MRPHS-3919)

**Problem**

GetTemplateList and GetDcImageList are similar with difference that GetTemplateList detailed information. Also, all clouds has method named GetImageList for this call, so it should be same here also.

**Resolution**
1. GetTemplateList is renamed as GetImageList and GetDcImageList is removed. So now there is only one method for retrieving image list information i.e. GetImageList.
Edit: After input from Deepali, kept GetTemplateList as it is in libretto to match it with vsphere terminology.

**Testing**
Unit tested all get call operations with dummy client. Logs attached.
 
[c3_getCalls.log](https://github.com/apporbit/libretto/files/1524889/c3_getCalls.log)

**Note:**
This change will require change in Halo and Appos(C3ntry).
PR for Halo: [MRPHS-3919](https://github.com/apporbit/halo/pull/65)
PR for Appos(C3ntry):  [MRPHS-3920](https://github.com/apporbit/appos/pull/281)
  