### PR TITLE
MRPHS-4409: GetImageList & GetVmList response parameter and CreateVMs Flavor parameter change

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -1030,7 +1030,7 @@ var reconfigureVM = func(vm *VM, vmMo *mo.VirtualMachine) error {
 
 		vDisk = CreateDisk(devices, controller, dsMo.Reference(), "",
 			thinProvisioned)
-		vDisk.CapacityInKB = disk.Size
+		vDisk.CapacityInKB = int64(disk.Size)
 		if err := vmObj.AddDevice(vm.ctx, vDisk); err != nil {
 			return fmt.Errorf("Failed to add device while creating "+
 				"Disks[%d] {%v} : %v", index, disk, err)
@@ -1773,4 +1773,204 @@ func checkAndCreateCustomSpec(vm *VM) error {
 		}
 	}
 	return nil
+}
+
+type VmProperties struct {
+	Name       string
+	Properties mo.VirtualMachine
+}
+
+// getVMsInAllDCs: Returns virtual machines from all DCs (entire inventory)
+func getVMsInAllDCs(vm *VM) ([]VmProperties, error) {
+	dcList, err := vm.finder.DatacenterList(vm.ctx, "*")
+	if err != nil {
+		return nil, fmt.Errorf("Error in getting datacenter "+
+			"list: %v", err)
+	}
+	allDCsVMs := make([]VmProperties, 0)
+	vmsInDc := make([]VmProperties, 0)
+	for _, dcObj := range dcList {
+		vmsInDc, err = getDcVMList(vm, dcObj)
+		if err != nil {
+			return nil, err
+		}
+		allDCsVMs = append(allDCsVMs, vmsInDc...)
+	}
+	return allDCsVMs, nil
+}
+
+// getHostsLookup: returns appropriate hostsLookup map for given destination
+// cluster/host
+func getHostsLookup(vm *VM) (map[string]bool, error) {
+	hostsLookup := make(map[string]bool)
+	// if host is provided update the hostsLookup map to have one host only
+	if vm.Destination.HostSystem != "" {
+		hostsLookup = map[string]bool{
+			vm.Destination.HostSystem: false,
+		}
+	} else {
+		var hsMos []mo.HostSystem
+		// Get the cluster resource and its host
+		dcMo, err := GetDatacenter(vm)
+		if err != nil {
+			return nil, err
+		}
+		crMo, err := findClusterComputeResource(vm, dcMo,
+			vm.Destination.DestinationName)
+		if err != nil {
+			return nil, err
+		}
+		// get the hosts in cluster
+		err = vm.collector.Retrieve(vm.ctx, crMo.Host, []string{"name"},
+			&hsMos)
+		if err != nil {
+			return nil, err
+		}
+		for _, host := range hsMos {
+			hostsLookup[host.Name] = false
+		}
+	}
+	return hostsLookup, nil
+}
+
+// getVirtualMachines : Returns the virtual machines in a allDCs/dc/cluster/host
+func getVirtualMachines(vm *VM, allDCs bool) ([]VmProperties, error) {
+	var (
+		hsMo mo.HostSystem
+	)
+
+	if allDCs {
+		return getVMsInAllDCs(vm)
+	}
+
+	// get virtual machines for the whole datacenter
+	vmsInDc := make([]VmProperties, 0)
+	dcMo, err := GetDatacenter(vm)
+	if err != nil {
+		return nil, err
+	}
+	dcObj := object.NewDatacenter(vm.client.Client,
+		dcMo.Reference())
+	vmsInDc, err = getDcVMList(vm, dcObj)
+	if err != nil {
+		return nil, err
+	}
+
+	// if cluster name not given, return vms in datacenter
+	if vm.Destination.DestinationName == "" {
+		return vmsInDc, nil
+	}
+
+	// using hostsLookup to check if a vm is related to a host in map
+	vmsInCluster := make([]VmProperties, 0)
+	hostsLookup, err := getHostsLookup(vm)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, vmProp := range vmsInDc {
+		vmMo := vmProp.Properties
+
+		if vmMo.Runtime.Host == nil {
+			continue
+		}
+		err = vm.collector.RetrieveOne(vm.ctx, *vmMo.Runtime.Host,
+			[]string{"name"}, &hsMo)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := hostsLookup[hsMo.Name]; ok {
+			vmsInCluster = append(vmsInCluster, VmProperties{
+				Name:       vmProp.Name,
+				Properties: vmMo})
+		}
+	}
+	return vmsInCluster, nil
+}
+
+// getDcVMList : returns list of VirtualMachine objects in a Datacenter
+func getDcVMList(vm *VM, datacenter *object.Datacenter) (
+	[]VmProperties, error) {
+	// Set datacenter
+	vm.finder.SetDatacenter(datacenter)
+	folders, err := datacenter.Folders(vm.ctx)
+	if err != nil {
+		return nil, err
+	}
+	// datacenter's vmFolder has all the vms in all the clusters/hosts in
+	// that datacetner, returning the vm in datacenter vmfolder
+	return getVmsInFolder(vm, folders.VmFolder, "")
+}
+
+// getVmsInFolder: returns list of VmProperties which has full path and
+// mo.Virtualmachine struct of vms in a vcenter vm folder
+func getVmsInFolder(vm *VM, folder *object.Folder, path string) (
+	[]VmProperties, error) {
+	allVms := make([]VmProperties, 0)
+	// get list of folders/vms/templates in folder
+	children, err := folder.Children(vm.ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, entity := range children {
+		mor := entity.Reference()
+		switch mor.Type {
+		// if child is a folder, look for vms in the folder recursively
+		// and add to the hash
+		case "Folder":
+			// Fetch the childEntity property of the folder
+			folderMo := mo.Folder{}
+			err := vm.collector.RetrieveOne(vm.ctx, mor, []string{
+				"name"}, &folderMo)
+			if err != nil {
+				if isObjectDeleted(err) {
+					continue
+				}
+				return nil, err
+			}
+			// unescaping to convert any escaped character
+			folderName, err := url.QueryUnescape(folderMo.Name)
+			if err != nil {
+				return nil, err
+			}
+			// Adding delimitter in case "/" is present in name
+			folderName = strings.Replace(folderName, "/", "\\/",
+				-1)
+			folder := object.NewFolder(vm.client.Client,
+				mor)
+			// gettings vm in folder recursively
+			vmProps, err := getVmsInFolder(vm, folder,
+				path+folderName+"/")
+			if err != nil {
+				return nil, err
+			}
+			// updating the allVMs hash
+			allVms = append(allVms, vmProps...)
+		case "VirtualMachine":
+			// if child is vm/template, return the full path and
+			// mo of the vm
+			vmMo := mo.VirtualMachine{}
+			err := vm.collector.RetrieveOne(vm.ctx, mor, []string{
+				"name", "guest", "config", "runtime",
+				"summary"}, &vmMo)
+			if err != nil {
+				if isObjectDeleted(err) {
+					continue
+				}
+				return nil, err
+			}
+			// unescaping to convert any escaped character
+			vmName, err := url.QueryUnescape(vmMo.Name)
+			if err != nil {
+				return nil, err
+			}
+			// Adding delimitter in case "/" is present in name
+			vmName = path + strings.Replace(vmName, "/", "\\/",
+				-1)
+			allVms = append(allVms, VmProperties{
+				Name:       vmName,
+				Properties: vmMo})
+		}
+	}
+	return allVms, nil
 }

--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -707,7 +707,7 @@ func removeExistingNetworks(vm *VM, vmObj *object.VirtualMachine) ([]types.BaseV
 // Function to search disk in disks array with its name
 func findByVirtualDeviceFileName(disks []Disk, name string) *Disk {
 	for _, disk := range disks {
-		if disk.DiskName == name {
+		if disk.DiskFile == name {
 			return &disk
 		}
 	}
@@ -1037,14 +1037,14 @@ var reconfigureVM = func(vm *VM, vmMo *mo.VirtualMachine) error {
 		}
 
 		// getting device list after adding disk and setting appropriate
-		// vmdk filename to DiskName
+		// vmdk filename to DiskFile
 		devices, err = vmObj.Device(vm.ctx)
 		if err != nil {
 			return fmt.Errorf("Failed to get devices after creating "+
 				"Disks[%d] {%v} : %v", index, disk, err)
 		}
 		vmdkFilename := diffDisks(devices, devListBefore)
-		vm.Disks[index].DiskName = vmdkFilename[0]
+		vm.Disks[index].DiskFile = vmdkFilename[0]
 	}
 
 	return nil

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -434,7 +434,7 @@ type Disk struct {
 	Controller   string `json:"controller,omitempty"`
 	Provisioning string `json:"provisioning,omitempty"`
 	Datastore    string `json:"datastore,omitempty"`
-	DiskName     string `json:"disk_name,omitempty"`
+	DiskName     string `json:"disk_file,omitempty"`
 }
 
 // Snapshot represents a vSphere snapshot to create
@@ -516,9 +516,9 @@ type Flavor struct {
 	// constants [FlavorLarge, FlavorSmall, FlavorMedium, FlavorCustom]
 	Name string
 	// Represents the number of CPUs
-	NumCPUs int32
+	NumCPUs int32 `json:"cpu"`
 	// Represents the size of main memory in MB
-	MemoryMB int64
+	MemoryMB int64 `json:"memory"`
 }
 
 var _ lvm.VirtualMachine = (*VM)(nil)
@@ -1421,9 +1421,14 @@ func GetClusterNetworkList(vm *VM, filter map[string][]string) ([]map[string]str
 	return networks, nil
 }
 
+type VmProperties struct {
+	Name       string
+	Properties mo.VirtualMachine
+}
+
 // getDcVMList : returns list of VirtualMachine objects in a Datacenter
 func getDcVMList(vm *VM, datacenter *object.Datacenter) (
-	map[string]mo.VirtualMachine, error) {
+	[]VmProperties, error) {
 	// Set datacenter
 	vm.finder.SetDatacenter(datacenter)
 	folders, err := datacenter.Folders(vm.ctx)
@@ -1438,11 +1443,8 @@ func getDcVMList(vm *VM, datacenter *object.Datacenter) (
 // getVmsInFolder: returns map of full path and mo.Virtualmachine struct of vms
 // in a vcenter vm folder
 func getVmsInFolder(vm *VM, folder *object.Folder, path string) (
-	map[string]mo.VirtualMachine, error) {
-	var (
-		allVms map[string]mo.VirtualMachine
-	)
-	allVms = make(map[string]mo.VirtualMachine)
+	[]VmProperties, error) {
+	allVms := make([]VmProperties, 0)
 	// get list of folders/vms/templates in folder
 	children, err := folder.Children(vm.ctx)
 	if err != nil {
@@ -1475,15 +1477,13 @@ func getVmsInFolder(vm *VM, folder *object.Folder, path string) (
 			folder := object.NewFolder(vm.client.Client,
 				mor)
 			// gettings vm in folder recursively
-			vms, err := getVmsInFolder(vm, folder,
+			vmProps, err := getVmsInFolder(vm, folder,
 				path+folderName+"/")
 			if err != nil {
 				return nil, err
 			}
 			// updating the allVMs hash
-			for name, vmMo := range vms {
-				allVms[name] = vmMo
-			}
+			allVms = append(allVms, vmProps...)
 		case "VirtualMachine":
 			// if child is vm/template, return the full path and
 			// mo of the vm
@@ -1505,7 +1505,9 @@ func getVmsInFolder(vm *VM, folder *object.Folder, path string) (
 			// Adding delimitter in case "/" is present in name
 			vmName = path + strings.Replace(vmName, "/", "\\/",
 				-1)
-			allVms[vmName] = vmMo
+			allVms = append(allVms, VmProperties{
+				Name:       vmName,
+				Properties: vmMo})
 		}
 	}
 	return allVms, nil
@@ -1711,9 +1713,12 @@ func getVmInfo(vmMo mo.VirtualMachine, vmPath string) map[string]interface{} {
 		}
 		backing := disk.Backing.(types.BaseVirtualDeviceFileBackingInfo)
 		fileBackingInfo := backing.GetVirtualDeviceFileBackingInfo()
+
+		diskSizeGB := disk.CapacityInKB / (1024 * 1024)
+
 		diskInfo = append(diskInfo, map[string]interface{}{
 			"name":      devinfo.Label,
-			"size":      disk.CapacityInKB,
+			"size":      diskSizeGB,
 			"disk_file": fileBackingInfo.FileName,
 		})
 	}
@@ -1723,23 +1728,24 @@ func getVmInfo(vmMo mo.VirtualMachine, vmPath string) map[string]interface{} {
 	}
 
 	return map[string]interface{}{
-		"name":           vmPath, // full name/path of vm
-		"id":             vmMo.Self.Value,
-		"instance_uuid":  vmMo.Summary.Config.InstanceUuid,
-		"memory_size_mb": vmMo.Summary.Config.MemorySizeMB,
-		"num_cpu":        vmMo.Summary.Config.NumCpu,
-		"disks":          diskInfo,
-		"ip_addresses":   getIpFromVmMo(&vmMo),
-		"nic_info":       getNicInfo(vmMo),
-		"os_details":     getOsDetails(vmMo),
-		"tool_status":    toolsStatus,
+		"name":          vmPath, // full name/path of vm
+		"path":          vmPath, // TODO set full inventory path of vm/template
+		"id":            vmMo.Self.Value,
+		"instance_uuid": vmMo.Summary.Config.InstanceUuid,
+		"memory":        vmMo.Summary.Config.MemorySizeMB,
+		"cpu":           vmMo.Summary.Config.NumCpu,
+		"disks":         diskInfo,
+		"ip_addresses":  getIpFromVmMo(&vmMo),
+		"nic_info":      getNicInfo(vmMo),
+		"os_details":    getOsDetails(vmMo),
+		"tool_status":   toolsStatus,
 	}
 }
 
 // GetVmList : Returns the VMs/templates info in a dc/cluster/host
 func GetVmList(vm *VM, markedTemplate bool) ([]map[string]interface{}, error) {
 	var err error
-	vmMoList := make(map[string]mo.VirtualMachine)
+	vmPropList := make([]VmProperties, 0)
 	vmList := make([]map[string]interface{}, 0)
 	// set up session to vcenter server
 	if err := SetupSession(vm); err != nil {
@@ -1753,18 +1759,25 @@ func GetVmList(vm *VM, markedTemplate bool) ([]map[string]interface{}, error) {
 			if err != nil {
 				return nil, err
 			}
-			vmMoList[vmMo.Name] = *vmMo
+			vmPropList = append(vmPropList, VmProperties{
+				Name:       vmMo.Name,
+				Properties: *vmMo})
 		}
 	} else {
-		vmMoList, err = getVirtualMachines(vm)
+		if vm.Datacenter == "" {
+			vmPropList, err = getVirtualMachines(vm, true)
+		} else {
+			vmPropList, err = getVirtualMachines(vm, false)
+		}
 		if err != nil {
 			return nil, err
 		}
 	}
-	if vmMoList == nil {
+	if vmPropList == nil {
 		return vmList, nil
 	}
-	for name, vmo := range vmMoList {
+	for _, vmProp := range vmPropList {
+		vmo := vmProp.Properties
 		// Filter out the templates
 		if vmo.Config == nil {
 			continue
@@ -1775,20 +1788,37 @@ func GetVmList(vm *VM, markedTemplate bool) ([]map[string]interface{}, error) {
 			!markedTemplate && vmo.Config.Template {
 			continue
 		}
-		vminfo := getVmInfo(vmo, name)
+		vminfo := getVmInfo(vmo, vmProp.Name)
 		vmList = append(vmList, vminfo)
 	}
 	return vmList, nil
 }
 
-// getVirtualMachines : Returns the virtual machines in a dc/cluster/host
-func getVirtualMachines(vm *VM) (map[string]mo.VirtualMachine, error) {
+// getVirtualMachines : Returns the virtual machines in a allDCs/dc/cluster/host
+func getVirtualMachines(vm *VM, allDCs bool) ([]VmProperties, error) {
 	var (
 		hsMos []mo.HostSystem
 		hsMo  mo.HostSystem
 	)
-	vmsInDc := make(map[string]mo.VirtualMachine)
-	vmsInCluster := make(map[string]mo.VirtualMachine)
+	vmsInDc := make([]VmProperties, 0)
+	vmsInCluster := make([]VmProperties, 0)
+
+	if allDCs {
+		dcList, err := vm.finder.DatacenterList(vm.ctx, "*")
+		if err != nil {
+			return nil, fmt.Errorf("Error in getting datacenter "+
+				"list: %v", err)
+		}
+		allDCsVMs := make([]VmProperties, 0)
+		for _, dcObj := range dcList {
+			vmsInDc, err = getDcVMList(vm, dcObj)
+			if err != nil {
+				return nil, err
+			}
+			allDCsVMs = append(allDCsVMs, vmsInDc...)
+		}
+		return allDCsVMs, nil
+	}
 
 	// Return virtual machines for the whole datacenter
 	dcMo, err := GetDatacenter(vm)
@@ -1833,7 +1863,9 @@ func getVirtualMachines(vm *VM) (map[string]mo.VirtualMachine, error) {
 		}
 	}
 
-	for path, vmMo := range vmsInDc {
+	for _, vmProp := range vmsInDc {
+		vmMo := vmProp.Properties
+
 		if vmMo.Runtime.Host == nil {
 			continue
 		}
@@ -1843,7 +1875,9 @@ func getVirtualMachines(vm *VM) (map[string]mo.VirtualMachine, error) {
 			return nil, err
 		}
 		if _, ok := hostsLookup[hsMo.Name]; ok {
-			vmsInCluster[path] = vmMo
+			vmsInCluster = append(vmsInCluster, VmProperties{
+				Name:       vmProp.Name,
+				Properties: vmMo})
 		}
 	}
 	return vmsInCluster, nil

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -430,11 +430,11 @@ type collector interface {
 
 // Disk represents a vSphere Disk to attach to the VM
 type Disk struct {
-	Size         int64  `json:"size,omitempty"`
-	Controller   string `json:"controller,omitempty"`
-	Provisioning string `json:"provisioning,omitempty"`
-	Datastore    string `json:"datastore,omitempty"`
-	DiskFile     string `json:"disk_file,omitempty"`
+	Size         float32 `json:"size,omitempty"`
+	Controller   string  `json:"controller,omitempty"`
+	Provisioning string  `json:"provisioning,omitempty"`
+	Datastore    string  `json:"datastore,omitempty"`
+	DiskFile     string  `json:"disk_file,omitempty"`
 }
 
 // Snapshot represents a vSphere snapshot to create
@@ -725,14 +725,13 @@ func (vm *VM) RemoveDisk() error {
 		return fmt.Errorf("Failed to retrieve datacenter: %v", err)
 	}
 
+	// finds the virtualmachine with name vm.Name
+	vmMo, err := findVM(vm, dcMo, vm.Name)
+	if err != nil {
+		return fmt.Errorf("VM :%s not found. Error : %v",
+			vm.Name, err)
+	}
 	for _, disk := range vm.Disks {
-		// finds the virtualmachine with name vm.Name
-		vmMo, err := findVM(vm, dcMo, vm.Name)
-		if err != nil {
-			return fmt.Errorf("VM :%s not found. Error : %v",
-				vm.Name, err)
-		}
-
 		// find the virtual disk to be removed from the vm
 		var deviceMo *types.VirtualDisk
 		for _, d := range vmMo.Config.Hardware.Device {
@@ -754,7 +753,7 @@ func (vm *VM) RemoveDisk() error {
 		// Creates the virtualmachine object to remove the disk
 		vmo := object.NewVirtualMachine(vm.client.Client, vmMo.Reference())
 		if err = vmo.RemoveDevice(vm.ctx, false, deviceMo); err != nil {
-			errorMessage += fmt.Errorf("%s : Delete disk task returned an error : %s \n", disk.DiskFile, err).Error()
+			errorMessage += fmt.Sprintf("%s : Delete disk task returned an error : %s \n", disk.DiskFile, err)
 		}
 	}
 	if errorMessage != "" {
@@ -976,7 +975,7 @@ func getDisksInfo(vmMo mo.VirtualMachine) []Disk {
 				} else {
 					diskInfo.Provisioning = "thick"
 				}
-				diskInfo.Size = disk.CapacityInBytes
+				diskInfo.Size = float32(disk.CapacityInBytes)
 				disksInfo = append(disksInfo, diskInfo)
 			}
 		}
@@ -1421,98 +1420,6 @@ func GetClusterNetworkList(vm *VM, filter map[string][]string) ([]map[string]str
 	return networks, nil
 }
 
-type VmProperties struct {
-	Name       string
-	Properties mo.VirtualMachine
-}
-
-// getDcVMList : returns list of VirtualMachine objects in a Datacenter
-func getDcVMList(vm *VM, datacenter *object.Datacenter) (
-	[]VmProperties, error) {
-	// Set datacenter
-	vm.finder.SetDatacenter(datacenter)
-	folders, err := datacenter.Folders(vm.ctx)
-	if err != nil {
-		return nil, err
-	}
-	// datacenter's vmFolder has all the vms in all the clusters/hosts in
-	// that datacetner, returning the vm in datacenter vmfolder
-	return getVmsInFolder(vm, folders.VmFolder, "")
-}
-
-// getVmsInFolder: returns list of VmProperties which has full path and
-// mo.Virtualmachine struct of vms in a vcenter vm folder
-func getVmsInFolder(vm *VM, folder *object.Folder, path string) (
-	[]VmProperties, error) {
-	allVms := make([]VmProperties, 0)
-	// get list of folders/vms/templates in folder
-	children, err := folder.Children(vm.ctx)
-	if err != nil {
-		return nil, err
-	}
-	for _, entity := range children {
-		mor := entity.Reference()
-		switch mor.Type {
-		// if child is a folder, look for vms in the folder recursively
-		// and add to the hash
-		case "Folder":
-			// Fetch the childEntity property of the folder
-			folderMo := mo.Folder{}
-			err := vm.collector.RetrieveOne(vm.ctx, mor, []string{
-				"name"}, &folderMo)
-			if err != nil {
-				if isObjectDeleted(err) {
-					continue
-				}
-				return nil, err
-			}
-			// unescaping to convert any escaped character
-			folderName, err := url.QueryUnescape(folderMo.Name)
-			if err != nil {
-				return nil, err
-			}
-			// Adding delimitter in case "/" is present in name
-			folderName = strings.Replace(folderName, "/", "\\/",
-				-1)
-			folder := object.NewFolder(vm.client.Client,
-				mor)
-			// gettings vm in folder recursively
-			vmProps, err := getVmsInFolder(vm, folder,
-				path+folderName+"/")
-			if err != nil {
-				return nil, err
-			}
-			// updating the allVMs hash
-			allVms = append(allVms, vmProps...)
-		case "VirtualMachine":
-			// if child is vm/template, return the full path and
-			// mo of the vm
-			vmMo := mo.VirtualMachine{}
-			err := vm.collector.RetrieveOne(vm.ctx, mor, []string{
-				"name", "guest", "config", "runtime",
-				"summary"}, &vmMo)
-			if err != nil {
-				if isObjectDeleted(err) {
-					continue
-				}
-				return nil, err
-			}
-			// unescaping to convert any escaped character
-			vmName, err := url.QueryUnescape(vmMo.Name)
-			if err != nil {
-				return nil, err
-			}
-			// Adding delimitter in case "/" is present in name
-			vmName = path + strings.Replace(vmName, "/", "\\/",
-				-1)
-			allVms = append(allVms, VmProperties{
-				Name:       vmName,
-				Properties: vmMo})
-		}
-	}
-	return allVms, nil
-}
-
 // GetDcClusterList : GetDcClusterList returns the clusters in the datacenter
 func GetDcClusterList(vm *VM) ([]ClusterComputeResource, error) {
 	var (
@@ -1714,7 +1621,7 @@ func getVmInfo(vmMo mo.VirtualMachine, vmPath string) map[string]interface{} {
 		backing := disk.Backing.(types.BaseVirtualDeviceFileBackingInfo)
 		fileBackingInfo := backing.GetVirtualDeviceFileBackingInfo()
 
-		diskSizeGB := disk.CapacityInKB / (1024 * 1024)
+		diskSizeGB := float32(disk.CapacityInKB) / (1024 * 1024)
 
 		diskInfo = append(diskInfo, map[string]interface{}{
 			"name":      devinfo.Label,
@@ -1764,11 +1671,12 @@ func GetVmList(vm *VM, markedTemplate bool) ([]map[string]interface{}, error) {
 				Properties: *vmMo})
 		}
 	} else {
+		searchInAllDCs := false
 		if vm.Datacenter == "" {
-			vmPropList, err = getVirtualMachines(vm, true)
-		} else {
-			vmPropList, err = getVirtualMachines(vm, false)
+			searchInAllDCs = true
 		}
+		vmPropList, err = getVirtualMachines(vm, searchInAllDCs)
+
 		if err != nil {
 			return nil, err
 		}
@@ -1792,95 +1700,6 @@ func GetVmList(vm *VM, markedTemplate bool) ([]map[string]interface{}, error) {
 		vmList = append(vmList, vminfo)
 	}
 	return vmList, nil
-}
-
-// getVirtualMachines : Returns the virtual machines in a allDCs/dc/cluster/host
-func getVirtualMachines(vm *VM, allDCs bool) ([]VmProperties, error) {
-	var (
-		hsMos []mo.HostSystem
-		hsMo  mo.HostSystem
-	)
-	vmsInDc := make([]VmProperties, 0)
-	vmsInCluster := make([]VmProperties, 0)
-
-	if allDCs {
-		dcList, err := vm.finder.DatacenterList(vm.ctx, "*")
-		if err != nil {
-			return nil, fmt.Errorf("Error in getting datacenter "+
-				"list: %v", err)
-		}
-		allDCsVMs := make([]VmProperties, 0)
-		for _, dcObj := range dcList {
-			vmsInDc, err = getDcVMList(vm, dcObj)
-			if err != nil {
-				return nil, err
-			}
-			allDCsVMs = append(allDCsVMs, vmsInDc...)
-		}
-		return allDCsVMs, nil
-	}
-
-	// Return virtual machines for the whole datacenter
-	dcMo, err := GetDatacenter(vm)
-	if err != nil {
-		return nil, err
-	}
-
-	dcObj := object.NewDatacenter(vm.client.Client,
-		dcMo.Reference())
-	vmsInDc, err = getDcVMList(vm, dcObj)
-	if err != nil {
-		return nil, err
-	}
-
-	// if cluster name not given, return vms in datacenter
-	if vm.Destination.DestinationName == "" {
-		return vmsInDc, nil
-	}
-
-	// using hostsLookup to check if a vm is related to a host in map
-	hostsLookup := make(map[string]bool)
-	// if host is provided update the hostsLookup map to have one host only
-	if vm.Destination.HostSystem != "" {
-		hostsLookup = map[string]bool{
-			vm.Destination.HostSystem: false,
-		}
-	} else {
-		// Get the cluster resource and its host
-		crMo, err := findClusterComputeResource(vm, dcMo,
-			vm.Destination.DestinationName)
-		if err != nil {
-			return nil, err
-		}
-		// get the hosts in cluster
-		err = vm.collector.Retrieve(vm.ctx, crMo.Host, []string{"name"},
-			&hsMos)
-		if err != nil {
-			return nil, err
-		}
-		for _, host := range hsMos {
-			hostsLookup[host.Name] = false
-		}
-	}
-
-	for _, vmProp := range vmsInDc {
-		vmMo := vmProp.Properties
-
-		if vmMo.Runtime.Host == nil {
-			continue
-		}
-		err = vm.collector.RetrieveOne(vm.ctx, *vmMo.Runtime.Host,
-			[]string{"name"}, &hsMo)
-		if err != nil {
-			return nil, err
-		}
-		if _, ok := hostsLookup[hsMo.Name]; ok {
-			vmsInCluster = append(vmsInCluster, VmProperties{
-				Name:       vmProp.Name,
-				Properties: vmMo})
-		}
-	}
-	return vmsInCluster, nil
 }
 
 // ConvertToTemplate : converts vm to vm template

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -434,7 +434,7 @@ type Disk struct {
 	Controller   string `json:"controller,omitempty"`
 	Provisioning string `json:"provisioning,omitempty"`
 	Datastore    string `json:"datastore,omitempty"`
-	DiskName     string `json:"disk_file,omitempty"`
+	DiskFile     string `json:"disk_file,omitempty"`
 }
 
 // Snapshot represents a vSphere snapshot to create
@@ -709,7 +709,7 @@ func (vm *VM) AddDisk() error {
 }
 
 // RemoveDisk: removes given list of disks attached to the virtualmachine 'vm'
-// disk.DiskName is the name of the vmdk file for the disk
+// disk.DiskFile is the name of the vmdk file for the disk
 func (vm *VM) RemoveDisk() error {
 	var errorMessage string
 	if err := SetupSession(vm); err != nil {
@@ -739,7 +739,7 @@ func (vm *VM) RemoveDisk() error {
 			switch device := d.(type) {
 			case *types.VirtualDisk:
 				fileName := d.GetVirtualDevice().Backing.(types.BaseVirtualDeviceFileBackingInfo).GetVirtualDeviceFileBackingInfo().FileName
-				if fileName == disk.DiskName {
+				if fileName == disk.DiskFile {
 					deviceMo = device
 					break
 				}
@@ -747,14 +747,14 @@ func (vm *VM) RemoveDisk() error {
 		}
 
 		if deviceMo == nil {
-			errorMessage += fmt.Sprintf("%s : No disk with name\n", disk.DiskName)
+			errorMessage += fmt.Sprintf("%s : No disk with name\n", disk.DiskFile)
 			continue
 		}
 
 		// Creates the virtualmachine object to remove the disk
 		vmo := object.NewVirtualMachine(vm.client.Client, vmMo.Reference())
 		if err = vmo.RemoveDevice(vm.ctx, false, deviceMo); err != nil {
-			errorMessage += fmt.Errorf("%s : Delete disk task returned an error : %s \n", disk.DiskName, err).Error()
+			errorMessage += fmt.Errorf("%s : Delete disk task returned an error : %s \n", disk.DiskFile, err).Error()
 		}
 	}
 	if errorMessage != "" {
@@ -970,7 +970,7 @@ func getDisksInfo(vmMo mo.VirtualMachine) []Disk {
 				diskInfo.Controller = controller
 				backing := disk.Backing
 				fileBackingInfo := backing.(types.BaseVirtualDeviceFileBackingInfo).GetVirtualDeviceFileBackingInfo()
-				diskInfo.DiskName = fileBackingInfo.FileName
+				diskInfo.DiskFile = fileBackingInfo.FileName
 				if *(backing.(*types.VirtualDiskFlatVer2BackingInfo)).ThinProvisioned {
 					diskInfo.Provisioning = "thin"
 				} else {
@@ -1440,8 +1440,8 @@ func getDcVMList(vm *VM, datacenter *object.Datacenter) (
 	return getVmsInFolder(vm, folders.VmFolder, "")
 }
 
-// getVmsInFolder: returns map of full path and mo.Virtualmachine struct of vms
-// in a vcenter vm folder
+// getVmsInFolder: returns list of VmProperties which has full path and
+// mo.Virtualmachine struct of vms in a vcenter vm folder
 func getVmsInFolder(vm *VM, folder *object.Folder, path string) (
 	[]VmProperties, error) {
 	allVms := make([]VmProperties, 0)


### PR DESCRIPTION
**Jira Id**

[MRPHS-4409](https://apporbit.atlassian.net/browse/MRPHS-4409)

**Problem**

1. GetImageList/GetVmList should send list for whole vcenter and Datacenter should be optional

2. Flavor name is not relevant in Vsphere so should be removed 

3. There are inconsistencies in GetImageList/GetVmList response and how it is required for CreateVMs. For example:

- vmdk fileName is returned under "disk_file" param but CreateVMs expect it to be "disk_name"
- memory is named as "memory_mb" where its actual unit is KB
- disk size is expected in GB where as response sends it in KB

Also after discussion with controller team some param names are changed for simplicity.

**Resolution**
Following changes are done with this PR:
1. CreateVMs :  - For flavor name is not required and is ignored even if it is given 
                         - Parameter name numCPUs is marshaled  to CPU in json
                         - Parameter name memoryMB is marshaled to memory in json
                         - "disk_name" is renamed to "disk_file" given for FixedDisk
2. RemoveDisk: - "disk_name" is renamed to "disk_file" 
2. GetImageList/GetVmList: - Made Datacenter parameter optional i.e. if given list is from that DC and if 
                                               not given then list is form complete VCenter
                                            - Added "path" which will contain full inventory path of template/vm. 
                                              Currently it shows partial path.
                                            - parameter "num_cpu" renamed to "cpu" in response
                                            - parameter "memory_mb" renamed to memory in response
                                            - "size" of disk is now returned in GB (as required in FixedDisks parameter in 
                                               CreateVMs)

**Testing**
Unit tested CreateVMs, AddDisk, RemoveDisk, GetImageList. Logs attached.
[c3_4409.log](https://github.com/apporbit/libretto/files/1628619/c3_4409.log)
