### PR TITLE
MRPHS-4594: Support Cross-Datacenter VM Creation where Template resides in different DC

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -63,13 +63,33 @@ func StringInSlice(str string, list []string) bool {
 	return false
 }
 
+// getVMSearchFilter: returns VMSearchFilter object for given vm
+// by default vm is searched within DC
+func getVMSearchFilter(vm *VM) VMSearchFilter {
+	searchFilter := VMSearchFilter{
+		Name:       vm.Name,
+		SearchInDC: true,
+	}
+	return searchFilter
+}
+
+// getTempSearchFilter: returns VMSearchFilter object for given template
+// by default template is searched in entire inventory (across dc)
+func getTempSearchFilter(template Template) VMSearchFilter {
+	searchFilter := VMSearchFilter{
+		Name:         template.Name,
+		InstanceUuid: template.InstanceUuid,
+		SearchInDC:   false,
+	}
+	return searchFilter
+}
+
 // mutex for custom spec creation
 var checkCustomSpecMutex sync.Mutex
 
 // Exists checks if the VM already exists.
-var Exists = func(vm *VM, dc *mo.Datacenter, tName string,
-	instanceUuid string) (bool, error) {
-	_, err := findVM(vm, dc, tName, instanceUuid)
+var Exists = func(vm *VM, searchFilter VMSearchFilter) (bool, error) {
+	_, err := findVM(vm, searchFilter)
 	if err != nil {
 		if _, ok := err.(ErrorObjectNotFound); ok {
 			return false, nil
@@ -394,22 +414,27 @@ var createRequest = func(r io.Reader, method string, insecure bool, length int64
 
 // findVM finds the vm Managed Object referenced by the name/instanceUuid
 // or returns an error if it is not found.
-var findVM = func(vm *VM, dc *mo.Datacenter, name string,
-	instanceUuid string) (*mo.VirtualMachine, error) {
+var findVM = func(vm *VM, searchFilter VMSearchFilter) (*mo.VirtualMachine,
+	error) {
 	var (
 		moVM *mo.VirtualMachine
+		dc   *mo.Datacenter
 		err  error
 	)
 
-	if instanceUuid != "" {
-		moVM, err = searchVmByUuid(vm, instanceUuid)
+	if searchFilter.InstanceUuid != "" {
+		moVM, err = searchVmByUuid(vm, searchFilter)
 	} else {
-		moVM, err = searchTree(vm, &dc.VmFolder, name)
+		dc, err = GetDatacenter(vm)
+		if err != nil {
+			return nil, err
+		}
+		moVM, err = searchTree(vm, &dc.VmFolder, searchFilter.Name)
+
 	}
 	if err != nil {
 		return moVM, err
 	}
-
 	// Having a question pending during operations usually cause errors forcing
 	// manual resolution. Anytime we look up a VM try first to resolve any
 	// questions that we know how to answer.
@@ -534,26 +559,41 @@ func searchTree(vm *VM, mor *types.ManagedObjectReference, name string) (
 		name)
 }
 
-// searchVmByUuid: searches a datacenter for vm with uuid: instanceUuid
-func searchVmByUuid(vm *VM, instanceUuid string) (*mo.VirtualMachine, error) {
+// searchVmByUuid: searches vm with uuid: instanceUuid in datacenter
+// or entire inventory
+func searchVmByUuid(vm *VM, searchFilter VMSearchFilter) (
+	*mo.VirtualMachine, error) {
+	var (
+		dcObj *object.Datacenter
+		obj   object.Reference
+		err   error
+		dcMo  *mo.Datacenter
+	)
 	vmMo := mo.VirtualMachine{}
 	s := object.NewSearchIndex(vm.client.Client)
 	isInstanceUuid := new(bool)
 	*isInstanceUuid = true
-	dcMo, err := GetDatacenter(vm)
+
+	if searchFilter.SearchInDC {
+		dcMo, err = GetDatacenter(vm)
+		if err != nil {
+			return nil, err
+		}
+		dcObj = object.NewDatacenter(vm.client.Client, dcMo.Self)
+		obj, err = s.FindByUuid(vm.ctx, dcObj, searchFilter.InstanceUuid, true,
+			isInstanceUuid)
+	} else {
+		obj, err = s.FindByUuid(vm.ctx, nil, searchFilter.InstanceUuid, true,
+			isInstanceUuid)
+	}
 	if err != nil {
 		return nil, err
 	}
-	dcObj := object.NewDatacenter(vm.client.Client, dcMo.Self)
-	obj, err := s.FindByUuid(vm.ctx, dcObj, instanceUuid, true,
-		isInstanceUuid)
-	if err != nil {
-		return nil, err
-	}
+
 	vmObj, ok := obj.(*object.VirtualMachine)
 	if !ok {
 		return nil, NewErrorObjectNotFound(errors.New(
-			"Invalid object with uuid found"), instanceUuid)
+			"Invalid object with uuid found"), searchFilter.InstanceUuid)
 	}
 	err = vm.collector.RetrieveOne(vm.ctx, vmObj.Reference(), []string{
 		"name", "config", "runtime", "summary", "guest"}, &vmMo)
@@ -781,10 +821,9 @@ var cloneFromTemplate = func(vm *VM, dcMo *mo.Datacenter, usableDatastores []str
 	var template string
 	if vm.UseLocalTemplates {
 		template = createTemplateName(vm.Template.Name, vm.datastore)
-	} else {
-		template = vm.Template.Name
+		vm.Template.Name = template
 	}
-	vmMo, err := findVM(vm, dcMo, template, vm.Template.InstanceUuid)
+	vmMo, err := findVM(vm, getTempSearchFilter(vm.Template))
 	if err != nil {
 		return fmt.Errorf("error retrieving template: %v", err)
 	}
@@ -901,7 +940,7 @@ var cloneFromTemplate = func(vm *VM, dcMo *mo.Datacenter, usableDatastores []str
 	if tInfo.Error != nil {
 		return fmt.Errorf("clone task finished with error: %v", tInfo.Error)
 	}
-	vmMo, err = findVM(vm, dcMo, vm.Name, "")
+	vmMo, err = findVM(vm, getVMSearchFilter(vm))
 	if err != nil {
 		return fmt.Errorf("failed to retrieve cloned VM: %v", err)
 	}
@@ -1089,11 +1128,7 @@ var halt = func(vm *VM) error {
 			return err
 		}
 	}
-	dcMo, err := GetDatacenter(vm)
-	if err != nil {
-		return err
-	}
-	vmMo, err := findVM(vm, dcMo, vm.Name, "")
+	vmMo, err := findVM(vm, getVMSearchFilter(vm))
 	if err != nil {
 		return err
 	}
@@ -1115,12 +1150,7 @@ var halt = func(vm *VM) error {
 
 // shutDown Initiates guest shut down of this VM.
 var shutDown = func(vm *VM) error {
-	// Get a reference to the datacenter with host and vm folders populated
-	dcMo, err := GetDatacenter(vm)
-	if err != nil {
-		return err
-	}
-	vmMo, err := findVM(vm, dcMo, vm.Name, "")
+	vmMo, err := findVM(vm, getVMSearchFilter(vm))
 	if err != nil {
 		return err
 	}
@@ -1197,12 +1227,7 @@ func waitForGuestStatus(vm *VM, vmMo *mo.VirtualMachine, status int,
 
 // restart Initiates guest reboot of this VM.
 var restart = func(vm *VM) error {
-	// Get a reference to the datacenter with host and vm folders populated
-	dcMo, err := GetDatacenter(vm)
-	if err != nil {
-		return err
-	}
-	vmMo, err := findVM(vm, dcMo, vm.Name, "")
+	vmMo, err := findVM(vm, getVMSearchFilter(vm))
 	if err != nil {
 		return err
 	}
@@ -1224,12 +1249,7 @@ var restart = func(vm *VM) error {
 }
 
 var start = func(vm *VM) error {
-	// Get a reference to the datacenter with host and vm folders populated
-	dcMo, err := GetDatacenter(vm)
-	if err != nil {
-		return err
-	}
-	vmMo, err := findVM(vm, dcMo, vm.Name, "")
+	vmMo, err := findVM(vm, getVMSearchFilter(vm))
 	if err != nil {
 		return err
 	}
@@ -1258,12 +1278,7 @@ var start = func(vm *VM) error {
 }
 
 var reset = func(vm *VM) error {
-	// Get a reference to the datacenter with host and vm folders populated
-	dcMo, err := GetDatacenter(vm)
-	if err != nil {
-		return err
-	}
-	vmMo, err := findVM(vm, dcMo, vm.Name, "")
+	vmMo, err := findVM(vm, getVMSearchFilter(vm))
 	if err != nil {
 		return err
 	}
@@ -1403,9 +1418,9 @@ var uploadTemplate = func(vm *VM, dcMo *mo.Datacenter, selectedDatastore string)
 	var template string
 	if vm.UseLocalTemplates {
 		template = createTemplateName(vm.Template.Name, selectedDatastore)
-	} else {
-		template = vm.Template.Name
+		vm.Template.Name = template
 	}
+
 	vm.datastore = selectedDatastore
 	downloadOvaPath, err := ioutil.TempDir("", "")
 	if err != nil {
@@ -1474,7 +1489,7 @@ var uploadTemplate = func(vm *VM, dcMo *mo.Datacenter, selectedDatastore string)
 		return fmt.Errorf("error uploading the ovf template: %v", err)
 	}
 
-	vmMo, err := findVM(vm, dcMo, template, vm.Template.InstanceUuid)
+	vmMo, err := findVM(vm, getTempSearchFilter(vm.Template))
 	if err != nil {
 		return fmt.Errorf("error getting the uploaded VM: %v", err)
 	}
@@ -1580,11 +1595,7 @@ func validateHost(vm *VM, hsMor types.ManagedObjectReference) (bool, error) {
 
 func getState(vm *VM) (state string, err error) {
 	// Get a reference to the datacenter with host and vm folders populated
-	dcMo, err := GetDatacenter(vm)
-	if err != nil {
-		return "", lvm.ErrVMInfoFailed
-	}
-	vmMo, err := findVM(vm, dcMo, vm.Name, "")
+	vmMo, err := findVM(vm, getVMSearchFilter(vm))
 	if err != nil {
 		return "", lvm.ErrVMInfoFailed
 	}

--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -63,11 +63,18 @@ func StringInSlice(str string, list []string) bool {
 	return false
 }
 
+// VMSearchFilter struct encapsulates all relevant search parameters
+type VMSearchFilter struct {
+	Name         string
+	InstanceUuid string
+	SearchInDC   bool
+}
+
 // getVMSearchFilter: returns VMSearchFilter object for given vm
 // by default vm is searched within DC
-func getVMSearchFilter(vm *VM) VMSearchFilter {
+func getVMSearchFilter(vmName string) VMSearchFilter {
 	searchFilter := VMSearchFilter{
-		Name:       vm.Name,
+		Name:       vmName,
 		SearchInDC: true,
 	}
 	return searchFilter
@@ -574,18 +581,18 @@ func searchVmByUuid(vm *VM, searchFilter VMSearchFilter) (
 	isInstanceUuid := new(bool)
 	*isInstanceUuid = true
 
+	dcObj = nil
+
 	if searchFilter.SearchInDC {
 		dcMo, err = GetDatacenter(vm)
 		if err != nil {
 			return nil, err
 		}
 		dcObj = object.NewDatacenter(vm.client.Client, dcMo.Self)
-		obj, err = s.FindByUuid(vm.ctx, dcObj, searchFilter.InstanceUuid, true,
-			isInstanceUuid)
-	} else {
-		obj, err = s.FindByUuid(vm.ctx, nil, searchFilter.InstanceUuid, true,
-			isInstanceUuid)
 	}
+
+	obj, err = s.FindByUuid(vm.ctx, dcObj, searchFilter.InstanceUuid, true,
+		isInstanceUuid)
 	if err != nil {
 		return nil, err
 	}
@@ -818,10 +825,8 @@ var cloneFromTemplate = func(vm *VM, dcMo *mo.Datacenter, usableDatastores []str
 		}
 		dsMor = dsMo.Reference()
 	}
-	var template string
 	if vm.UseLocalTemplates {
-		template = createTemplateName(vm.Template.Name, vm.datastore)
-		vm.Template.Name = template
+		vm.Template.Name = createTemplateName(vm.Template.Name, vm.datastore)
 	}
 	vmMo, err := findVM(vm, getTempSearchFilter(vm.Template))
 	if err != nil {
@@ -940,7 +945,7 @@ var cloneFromTemplate = func(vm *VM, dcMo *mo.Datacenter, usableDatastores []str
 	if tInfo.Error != nil {
 		return fmt.Errorf("clone task finished with error: %v", tInfo.Error)
 	}
-	vmMo, err = findVM(vm, getVMSearchFilter(vm))
+	vmMo, err = findVM(vm, getVMSearchFilter(vm.Name))
 	if err != nil {
 		return fmt.Errorf("failed to retrieve cloned VM: %v", err)
 	}
@@ -1128,7 +1133,7 @@ var halt = func(vm *VM) error {
 			return err
 		}
 	}
-	vmMo, err := findVM(vm, getVMSearchFilter(vm))
+	vmMo, err := findVM(vm, getVMSearchFilter(vm.Name))
 	if err != nil {
 		return err
 	}
@@ -1150,7 +1155,7 @@ var halt = func(vm *VM) error {
 
 // shutDown Initiates guest shut down of this VM.
 var shutDown = func(vm *VM) error {
-	vmMo, err := findVM(vm, getVMSearchFilter(vm))
+	vmMo, err := findVM(vm, getVMSearchFilter(vm.Name))
 	if err != nil {
 		return err
 	}
@@ -1227,7 +1232,7 @@ func waitForGuestStatus(vm *VM, vmMo *mo.VirtualMachine, status int,
 
 // restart Initiates guest reboot of this VM.
 var restart = func(vm *VM) error {
-	vmMo, err := findVM(vm, getVMSearchFilter(vm))
+	vmMo, err := findVM(vm, getVMSearchFilter(vm.Name))
 	if err != nil {
 		return err
 	}
@@ -1249,7 +1254,7 @@ var restart = func(vm *VM) error {
 }
 
 var start = func(vm *VM) error {
-	vmMo, err := findVM(vm, getVMSearchFilter(vm))
+	vmMo, err := findVM(vm, getVMSearchFilter(vm.Name))
 	if err != nil {
 		return err
 	}
@@ -1278,7 +1283,7 @@ var start = func(vm *VM) error {
 }
 
 var reset = func(vm *VM) error {
-	vmMo, err := findVM(vm, getVMSearchFilter(vm))
+	vmMo, err := findVM(vm, getVMSearchFilter(vm.Name))
 	if err != nil {
 		return err
 	}
@@ -1595,7 +1600,7 @@ func validateHost(vm *VM, hsMor types.ManagedObjectReference) (bool, error) {
 
 func getState(vm *VM) (state string, err error) {
 	// Get a reference to the datacenter with host and vm folders populated
-	vmMo, err := findVM(vm, getVMSearchFilter(vm))
+	vmMo, err := findVM(vm, getVMSearchFilter(vm.Name))
 	if err != nil {
 		return "", lvm.ErrVMInfoFailed
 	}

--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -67,8 +67,9 @@ func StringInSlice(str string, list []string) bool {
 var checkCustomSpecMutex sync.Mutex
 
 // Exists checks if the VM already exists.
-var Exists = func(vm *VM, dc *mo.Datacenter, tName string) (bool, error) {
-	_, err := findVM(vm, dc, tName)
+var Exists = func(vm *VM, dc *mo.Datacenter, tName string,
+	instanceUuid string) (bool, error) {
+	_, err := findVM(vm, dc, tName, instanceUuid)
 	if err != nil {
 		if _, ok := err.(ErrorObjectNotFound); ok {
 			return false, nil
@@ -391,9 +392,20 @@ var createRequest = func(r io.Reader, method string, insecure bool, length int64
 	return nil
 }
 
-// findVM finds the vm Managed Object referenced by the name or returns an error if it is not found.
-var findVM = func(vm *VM, dc *mo.Datacenter, name string) (*mo.VirtualMachine, error) {
-	moVM, err := searchTree(vm, &dc.VmFolder, name)
+// findVM finds the vm Managed Object referenced by the name/instanceUuid
+// or returns an error if it is not found.
+var findVM = func(vm *VM, dc *mo.Datacenter, name string,
+	instanceUuid string) (*mo.VirtualMachine, error) {
+	var (
+		moVM *mo.VirtualMachine
+		err  error
+	)
+
+	if instanceUuid != "" {
+		moVM, err = searchVmByUuid(vm, instanceUuid)
+	} else {
+		moVM, err = searchTree(vm, &dc.VmFolder, name)
+	}
 	if err != nil {
 		return moVM, err
 	}
@@ -544,7 +556,7 @@ func searchVmByUuid(vm *VM, instanceUuid string) (*mo.VirtualMachine, error) {
 			"Invalid object with uuid found"), instanceUuid)
 	}
 	err = vm.collector.RetrieveOne(vm.ctx, vmObj.Reference(), []string{
-		"name", "config", "runtime", "summary"}, &vmMo)
+		"name", "config", "runtime", "summary", "guest"}, &vmMo)
 	if err != nil {
 		return nil, err
 	}
@@ -768,11 +780,11 @@ var cloneFromTemplate = func(vm *VM, dcMo *mo.Datacenter, usableDatastores []str
 	}
 	var template string
 	if vm.UseLocalTemplates {
-		template = createTemplateName(vm.Template, vm.datastore)
+		template = createTemplateName(vm.Template.Name, vm.datastore)
 	} else {
-		template = vm.Template
+		template = vm.Template.Name
 	}
-	vmMo, err := findVM(vm, dcMo, template)
+	vmMo, err := findVM(vm, dcMo, template, vm.Template.InstanceUuid)
 	if err != nil {
 		return fmt.Errorf("error retrieving template: %v", err)
 	}
@@ -889,7 +901,7 @@ var cloneFromTemplate = func(vm *VM, dcMo *mo.Datacenter, usableDatastores []str
 	if tInfo.Error != nil {
 		return fmt.Errorf("clone task finished with error: %v", tInfo.Error)
 	}
-	vmMo, err = findVM(vm, dcMo, vm.Name)
+	vmMo, err = findVM(vm, dcMo, vm.Name, "")
 	if err != nil {
 		return fmt.Errorf("failed to retrieve cloned VM: %v", err)
 	}
@@ -1081,7 +1093,7 @@ var halt = func(vm *VM) error {
 	if err != nil {
 		return err
 	}
-	vmMo, err := findVM(vm, dcMo, vm.Name)
+	vmMo, err := findVM(vm, dcMo, vm.Name, "")
 	if err != nil {
 		return err
 	}
@@ -1108,7 +1120,7 @@ var shutDown = func(vm *VM) error {
 	if err != nil {
 		return err
 	}
-	vmMo, err := findVM(vm, dcMo, vm.Name)
+	vmMo, err := findVM(vm, dcMo, vm.Name, "")
 	if err != nil {
 		return err
 	}
@@ -1190,7 +1202,7 @@ var restart = func(vm *VM) error {
 	if err != nil {
 		return err
 	}
-	vmMo, err := findVM(vm, dcMo, vm.Name)
+	vmMo, err := findVM(vm, dcMo, vm.Name, "")
 	if err != nil {
 		return err
 	}
@@ -1217,7 +1229,7 @@ var start = func(vm *VM) error {
 	if err != nil {
 		return err
 	}
-	vmMo, err := findVM(vm, dcMo, vm.Name)
+	vmMo, err := findVM(vm, dcMo, vm.Name, "")
 	if err != nil {
 		return err
 	}
@@ -1251,7 +1263,7 @@ var reset = func(vm *VM) error {
 	if err != nil {
 		return err
 	}
-	vmMo, err := findVM(vm, dcMo, vm.Name)
+	vmMo, err := findVM(vm, dcMo, vm.Name, "")
 	if err != nil {
 		return err
 	}
@@ -1390,9 +1402,9 @@ var createTemplateName = func(t string, ds string) string {
 var uploadTemplate = func(vm *VM, dcMo *mo.Datacenter, selectedDatastore string) error {
 	var template string
 	if vm.UseLocalTemplates {
-		template = createTemplateName(vm.Template, selectedDatastore)
+		template = createTemplateName(vm.Template.Name, selectedDatastore)
 	} else {
-		template = vm.Template
+		template = vm.Template.Name
 	}
 	vm.datastore = selectedDatastore
 	downloadOvaPath, err := ioutil.TempDir("", "")
@@ -1462,7 +1474,7 @@ var uploadTemplate = func(vm *VM, dcMo *mo.Datacenter, selectedDatastore string)
 		return fmt.Errorf("error uploading the ovf template: %v", err)
 	}
 
-	vmMo, err := findVM(vm, dcMo, template)
+	vmMo, err := findVM(vm, dcMo, template, vm.Template.InstanceUuid)
 	if err != nil {
 		return fmt.Errorf("error getting the uploaded VM: %v", err)
 	}
@@ -1572,7 +1584,7 @@ func getState(vm *VM) (state string, err error) {
 	if err != nil {
 		return "", lvm.ErrVMInfoFailed
 	}
-	vmMo, err := findVM(vm, dcMo, vm.Name)
+	vmMo, err := findVM(vm, dcMo, vm.Name, "")
 	if err != nil {
 		return "", lvm.ErrVMInfoFailed
 	}

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -526,6 +526,13 @@ type Template struct {
 	InstanceUuid string `json:"instance_uuid"`
 }
 
+// VMSearchFilter struct encapsulates all relevant search parameters
+type VMSearchFilter struct {
+	Name         string
+	InstanceUuid string
+	SearchInDC   bool
+}
+
 var _ lvm.VirtualMachine = (*VM)(nil)
 
 // VM represents a vSphere VM.
@@ -620,9 +627,10 @@ func (vm *VM) Provision() (err error) {
 	for _, d := range datastores {
 		if vm.UseLocalTemplates {
 			template = createTemplateName(vm.Template.Name, d)
+			vm.Template.Name = template
 		}
 		// Does the VM template already exist?
-		e, err := Exists(vm, dcMo, template, vm.Template.InstanceUuid)
+		e, err := Exists(vm, getTempSearchFilter(vm.Template))
 		if err != nil {
 			return fmt.Errorf("failed to check if the template already exists: %v", err)
 		}
@@ -659,7 +667,7 @@ func (vm *VM) Provision() (err error) {
 	}
 
 	// Does the VM already exist?
-	e, err := Exists(vm, dcMo, vm.Name, "")
+	e, err := Exists(vm, getVMSearchFilter(vm))
 	if err != nil {
 		return fmt.Errorf("failed to check if the vm already exists: %v", err)
 	}
@@ -688,14 +696,8 @@ func (vm *VM) AddDisk() error {
 	// Cancel the sdk context
 	defer vm.cancel()
 
-	// Get a reference to the datacenter with host and vm folders populated
-	dcMo, err := GetDatacenter(vm)
-	if err != nil {
-		return fmt.Errorf("Failed to retrieve datacenter: %v", err)
-	}
-
 	// Finds the vm with name vm.Name
-	vmMo, err := findVM(vm, dcMo, vm.Name, "")
+	vmMo, err := findVM(vm, getVMSearchFilter(vm))
 	if err != nil {
 		return fmt.Errorf("VM :%s not found. Error : %v",
 			vm.Name, err)
@@ -724,18 +726,13 @@ func (vm *VM) RemoveDisk() error {
 	// Cancel the sdk context
 	defer vm.cancel()
 
-	// Get a reference to the datacenter with host and vm folders populated
-	dcMo, err := GetDatacenter(vm)
-	if err != nil {
-		return fmt.Errorf("Failed to retrieve datacenter: %v", err)
-	}
-
 	// finds the virtualmachine with name vm.Name
-	vmMo, err := findVM(vm, dcMo, vm.Name)
+	vmMo, err := findVM(vm, getVMSearchFilter(vm))
 	if err != nil {
 		return fmt.Errorf("VM :%s not found. Error : %v",
 			vm.Name, err)
 	}
+
 	for _, disk := range vm.Disks {
 		// find the virtual disk to be removed from the vm
 		var deviceMo *types.VirtualDisk
@@ -818,12 +815,7 @@ func (vm *VM) GetIPsAndIds() (VMInfo, error) {
 	}
 	defer vm.cancel()
 
-	// Get a reference to the datacenter with host and vm folders populated
-	dcMo, err := GetDatacenter(vm)
-	if err != nil {
-		return vmInfo, err
-	}
-	vmMo, err := findVM(vm, dcMo, vm.Name, "")
+	vmMo, err := findVM(vm, getVMSearchFilter(vm))
 	if err != nil {
 		return vmInfo, err
 	}
@@ -851,12 +843,7 @@ func (vm *VM) Destroy() (err error) {
 	}
 	defer vm.cancel()
 
-	// Get a reference to the datacenter with host and vm folders populated
-	dcMo, err := GetDatacenter(vm)
-	if err != nil {
-		return err
-	}
-	exists, err := Exists(vm, dcMo, vm.Name, "")
+	exists, err := Exists(vm, getVMSearchFilter(vm))
 	if err != nil {
 		return err
 	}
@@ -921,7 +908,7 @@ func (vm *VM) Destroy() (err error) {
 		}
 	}
 
-	vmMo, err := findVM(vm, dcMo, vm.Name, "")
+	vmMo, err := findVM(vm, getVMSearchFilter(vm))
 	if err != nil {
 		return err
 	}
@@ -997,12 +984,7 @@ func (vm *VM) GetVMInfo() (VMInfo, error) {
 	}
 	defer vm.cancel()
 
-	// Get a reference to the datacenter with host and vm folders populated
-	dcMo, err := GetDatacenter(vm)
-	if err != nil {
-		return vmInfo, err
-	}
-	vmMo, err := findVM(vm, dcMo, vm.Name, "")
+	vmMo, err := findVM(vm, getVMSearchFilter(vm))
 	if err != nil {
 		return vmInfo, err
 	}
@@ -1052,12 +1034,7 @@ func (vm *VM) Suspend() (err error) {
 	}
 	defer vm.cancel()
 
-	// Get a reference to the datacenter with host and vm folders populated
-	dcMo, err := GetDatacenter(vm)
-	if err != nil {
-		return err
-	}
-	vmMo, err := findVM(vm, dcMo, vm.Name, "")
+	vmMo, err := findVM(vm, getVMSearchFilter(vm))
 	if err != nil {
 		return err
 	}
@@ -1162,13 +1139,10 @@ func DeleteTemplate(vm *VM) error {
 	if err := SetupSession(vm); err != nil {
 		return err
 	}
-	dcMo, err := GetDatacenter(vm)
-	if err != nil {
-		return fmt.Errorf("Failed to retrieve datacenter: %v", err)
-	}
+
 	// find and delete vm-templates from all provided datastores
 	if !vm.UseLocalTemplates {
-		vmMo, err := findVM(vm, dcMo, vm.Template.Name, vm.Template.InstanceUuid)
+		vmMo, err := findVM(vm, getTempSearchFilter(vm.Template))
 		if err != nil {
 			return err
 		}
@@ -1177,12 +1151,13 @@ func DeleteTemplate(vm *VM) error {
 	}
 	for _, datastore := range vm.Datastores {
 		// generate template name <provided-name>-<datastore-name>
-		template := createTemplateName(vm.Template.Name, datastore)
+		templateCopy := vm.Template
+		templateCopy.Name = createTemplateName(vm.Template.Name, datastore)
 		// finds the template vm in Host specified in vm.Destination in Datacenter dcMo
-		templateVm, err := findVM(vm, dcMo, template, vm.Template.InstanceUuid)
+		templateVm, err := findVM(vm, getTempSearchFilter(templateCopy))
 		if err != nil {
 			// add to missing templates list if it doesn't exist or in case of error
-			missingTemplates = append(missingTemplates, template)
+			missingTemplates = append(missingTemplates, templateCopy.Name)
 			continue
 		}
 		err = deleteVM(vm, templateVm)
@@ -1582,7 +1557,9 @@ func CreateTemplate(vm *VM) error {
 		return err
 	}
 
-	_, err = findVM(vm, dcMo, vm.Template.Name, vm.Template.InstanceUuid)
+	searchFilter := getTempSearchFilter(vm.Template)
+	searchFilter.SearchInDC = true
+	_, err = findVM(vm, searchFilter)
 	if err == nil {
 		return fmt.Errorf("%s : Template already exists", vm.Template.Name)
 	}
@@ -1666,8 +1643,12 @@ func GetVmList(vm *VM, markedTemplate bool) ([]map[string]interface{}, error) {
 	defer vm.cancel()
 
 	if len(vm.InstanceUuids) != 0 {
+		searchFilter := VMSearchFilter{
+			SearchInDC: true,
+		}
 		for _, instanceUuid := range vm.InstanceUuids {
-			vmMo, err := searchVmByUuid(vm, instanceUuid)
+			searchFilter.InstanceUuid = instanceUuid
+			vmMo, err := searchVmByUuid(vm, searchFilter)
 			if err != nil {
 				return nil, err
 			}
@@ -1715,12 +1696,7 @@ func ConvertToTemplate(vm *VM) error {
 	}
 	defer vm.cancel()
 
-	dcMo, err := GetDatacenter(vm)
-	if err != nil {
-		return err
-	}
-
-	vmMo, err := findVM(vm, dcMo, vm.Name, "")
+	vmMo, err := findVM(vm, getVMSearchFilter(vm))
 	if err != nil {
 		return fmt.Errorf("error getting the uploaded VM: %v", err)
 	}

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -521,6 +521,11 @@ type Flavor struct {
 	MemoryMB int64 `json:"memory"`
 }
 
+type Template struct {
+	Name         string `json:"name"`
+	InstanceUuid string `json:"instance_uuid"`
+}
+
 var _ lvm.VirtualMachine = (*VM)(nil)
 
 // VM represents a vSphere VM.
@@ -553,7 +558,7 @@ type VM struct {
 	// InstanceUuids is the list of instance uuids for the VMs on vcenter server
 	InstanceUuids []string
 	// Template is the name to use for the VM's template
-	Template string
+	Template Template
 	// Datastores is a slice of permissible datastores. One is picked out of these.
 	Datastores []string
 	// UseLocalTemplates is a flag to indicate whether a template should be uploaded on all
@@ -610,14 +615,14 @@ func (vm *VM) Provision() (err error) {
 	}
 
 	var template string
-	template = vm.Template
+	template = vm.Template.Name
 	usableDatastores := []string{}
 	for _, d := range datastores {
 		if vm.UseLocalTemplates {
-			template = createTemplateName(vm.Template, d)
+			template = createTemplateName(vm.Template.Name, d)
 		}
 		// Does the VM template already exist?
-		e, err := Exists(vm, dcMo, template)
+		e, err := Exists(vm, dcMo, template, vm.Template.InstanceUuid)
 		if err != nil {
 			return fmt.Errorf("failed to check if the template already exists: %v", err)
 		}
@@ -630,7 +635,7 @@ func (vm *VM) Provision() (err error) {
 			switch *vm.SkipExisting {
 			case SKIPTEMPLATE_USE: //PASS
 			case SKIPTEMPLATE_ERROR:
-				return fmt.Errorf("Template already exists: %s", vm.Template)
+				return fmt.Errorf("Template already exists: %s", vm.Template.Name)
 			case SKIPTEMPLATE_OVERWRITE:
 				if err := DeleteTemplate(vm); err != nil {
 					return err
@@ -654,7 +659,7 @@ func (vm *VM) Provision() (err error) {
 	}
 
 	// Does the VM already exist?
-	e, err := Exists(vm, dcMo, vm.Name)
+	e, err := Exists(vm, dcMo, vm.Name, "")
 	if err != nil {
 		return fmt.Errorf("failed to check if the vm already exists: %v", err)
 	}
@@ -690,7 +695,7 @@ func (vm *VM) AddDisk() error {
 	}
 
 	// Finds the vm with name vm.Name
-	vmMo, err := findVM(vm, dcMo, vm.Name)
+	vmMo, err := findVM(vm, dcMo, vm.Name, "")
 	if err != nil {
 		return fmt.Errorf("VM :%s not found. Error : %v",
 			vm.Name, err)
@@ -818,7 +823,7 @@ func (vm *VM) GetIPsAndIds() (VMInfo, error) {
 	if err != nil {
 		return vmInfo, err
 	}
-	vmMo, err := findVM(vm, dcMo, vm.Name)
+	vmMo, err := findVM(vm, dcMo, vm.Name, "")
 	if err != nil {
 		return vmInfo, err
 	}
@@ -851,7 +856,7 @@ func (vm *VM) Destroy() (err error) {
 	if err != nil {
 		return err
 	}
-	exists, err := Exists(vm, dcMo, vm.Name)
+	exists, err := Exists(vm, dcMo, vm.Name, "")
 	if err != nil {
 		return err
 	}
@@ -916,7 +921,7 @@ func (vm *VM) Destroy() (err error) {
 		}
 	}
 
-	vmMo, err := findVM(vm, dcMo, vm.Name)
+	vmMo, err := findVM(vm, dcMo, vm.Name, "")
 	if err != nil {
 		return err
 	}
@@ -997,7 +1002,7 @@ func (vm *VM) GetVMInfo() (VMInfo, error) {
 	if err != nil {
 		return vmInfo, err
 	}
-	vmMo, err := findVM(vm, dcMo, vm.Name)
+	vmMo, err := findVM(vm, dcMo, vm.Name, "")
 	if err != nil {
 		return vmInfo, err
 	}
@@ -1052,7 +1057,7 @@ func (vm *VM) Suspend() (err error) {
 	if err != nil {
 		return err
 	}
-	vmMo, err := findVM(vm, dcMo, vm.Name)
+	vmMo, err := findVM(vm, dcMo, vm.Name, "")
 	if err != nil {
 		return err
 	}
@@ -1163,7 +1168,7 @@ func DeleteTemplate(vm *VM) error {
 	}
 	// find and delete vm-templates from all provided datastores
 	if !vm.UseLocalTemplates {
-		vmMo, err := findVM(vm, dcMo, vm.Template)
+		vmMo, err := findVM(vm, dcMo, vm.Template.Name, vm.Template.InstanceUuid)
 		if err != nil {
 			return err
 		}
@@ -1172,9 +1177,9 @@ func DeleteTemplate(vm *VM) error {
 	}
 	for _, datastore := range vm.Datastores {
 		// generate template name <provided-name>-<datastore-name>
-		template := createTemplateName(vm.Template, datastore)
+		template := createTemplateName(vm.Template.Name, datastore)
 		// finds the template vm in Host specified in vm.Destination in Datacenter dcMo
-		templateVm, err := findVM(vm, dcMo, template)
+		templateVm, err := findVM(vm, dcMo, template, vm.Template.InstanceUuid)
 		if err != nil {
 			// add to missing templates list if it doesn't exist or in case of error
 			missingTemplates = append(missingTemplates, template)
@@ -1577,9 +1582,9 @@ func CreateTemplate(vm *VM) error {
 		return err
 	}
 
-	_, err = findVM(vm, dcMo, vm.Template)
+	_, err = findVM(vm, dcMo, vm.Template.Name, vm.Template.InstanceUuid)
 	if err == nil {
-		return fmt.Errorf("%s : Template already exists", vm.Template)
+		return fmt.Errorf("%s : Template already exists", vm.Template.Name)
 	}
 	//selects a datstore at random and uploads the template
 	vm.datastore = util.ChooseRandomString(vm.Datastores)
@@ -1715,7 +1720,7 @@ func ConvertToTemplate(vm *VM) error {
 		return err
 	}
 
-	vmMo, err := findVM(vm, dcMo, vm.Name)
+	vmMo, err := findVM(vm, dcMo, vm.Name, "")
 	if err != nil {
 		return fmt.Errorf("error getting the uploaded VM: %v", err)
 	}

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -526,13 +526,6 @@ type Template struct {
 	InstanceUuid string `json:"instance_uuid"`
 }
 
-// VMSearchFilter struct encapsulates all relevant search parameters
-type VMSearchFilter struct {
-	Name         string
-	InstanceUuid string
-	SearchInDC   bool
-}
-
 var _ lvm.VirtualMachine = (*VM)(nil)
 
 // VM represents a vSphere VM.
@@ -667,7 +660,7 @@ func (vm *VM) Provision() (err error) {
 	}
 
 	// Does the VM already exist?
-	e, err := Exists(vm, getVMSearchFilter(vm))
+	e, err := Exists(vm, getVMSearchFilter(vm.Name))
 	if err != nil {
 		return fmt.Errorf("failed to check if the vm already exists: %v", err)
 	}
@@ -697,7 +690,7 @@ func (vm *VM) AddDisk() error {
 	defer vm.cancel()
 
 	// Finds the vm with name vm.Name
-	vmMo, err := findVM(vm, getVMSearchFilter(vm))
+	vmMo, err := findVM(vm, getVMSearchFilter(vm.Name))
 	if err != nil {
 		return fmt.Errorf("VM :%s not found. Error : %v",
 			vm.Name, err)
@@ -727,7 +720,7 @@ func (vm *VM) RemoveDisk() error {
 	defer vm.cancel()
 
 	// finds the virtualmachine with name vm.Name
-	vmMo, err := findVM(vm, getVMSearchFilter(vm))
+	vmMo, err := findVM(vm, getVMSearchFilter(vm.Name))
 	if err != nil {
 		return fmt.Errorf("VM :%s not found. Error : %v",
 			vm.Name, err)
@@ -815,7 +808,7 @@ func (vm *VM) GetIPsAndIds() (VMInfo, error) {
 	}
 	defer vm.cancel()
 
-	vmMo, err := findVM(vm, getVMSearchFilter(vm))
+	vmMo, err := findVM(vm, getVMSearchFilter(vm.Name))
 	if err != nil {
 		return vmInfo, err
 	}
@@ -843,7 +836,7 @@ func (vm *VM) Destroy() (err error) {
 	}
 	defer vm.cancel()
 
-	exists, err := Exists(vm, getVMSearchFilter(vm))
+	exists, err := Exists(vm, getVMSearchFilter(vm.Name))
 	if err != nil {
 		return err
 	}
@@ -908,7 +901,7 @@ func (vm *VM) Destroy() (err error) {
 		}
 	}
 
-	vmMo, err := findVM(vm, getVMSearchFilter(vm))
+	vmMo, err := findVM(vm, getVMSearchFilter(vm.Name))
 	if err != nil {
 		return err
 	}
@@ -984,7 +977,7 @@ func (vm *VM) GetVMInfo() (VMInfo, error) {
 	}
 	defer vm.cancel()
 
-	vmMo, err := findVM(vm, getVMSearchFilter(vm))
+	vmMo, err := findVM(vm, getVMSearchFilter(vm.Name))
 	if err != nil {
 		return vmInfo, err
 	}
@@ -1034,7 +1027,7 @@ func (vm *VM) Suspend() (err error) {
 	}
 	defer vm.cancel()
 
-	vmMo, err := findVM(vm, getVMSearchFilter(vm))
+	vmMo, err := findVM(vm, getVMSearchFilter(vm.Name))
 	if err != nil {
 		return err
 	}
@@ -1696,7 +1689,7 @@ func ConvertToTemplate(vm *VM) error {
 	}
 	defer vm.cancel()
 
-	vmMo, err := findVM(vm, getVMSearchFilter(vm))
+	vmMo, err := findVM(vm, getVMSearchFilter(vm.Name))
 	if err != nil {
 		return fmt.Errorf("error getting the uploaded VM: %v", err)
 	}


### PR DESCRIPTION
**Jira Id**

[MRPHS-4594](https://apporbit.atlassian.net/browse/MRPHS-4594)

**Problem**
Cross-Datacenter VM Creation should be supported where template resides in different DC than target DC where VM is to be created.
For this template should be searched with instanceUuid instead of name.

**Resolution**
Changed Template parameter from string to Struct which accepts InstanceUuid along with Name and modified search for template to use InstanceUuid.

**Testing**
Unit tested Create, ShutDown, Start, Stop, Reset and Delete operation for VM. Logs attached.
[c3_4594.log](https://github.com/apporbit/libretto/files/1628681/c3_4594.log)

