### PR TITLE
MRPHS-4596: Add custom field to Visor images during creation and add GetVisorList call

### DIFF
--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -41,6 +41,7 @@ const (
 	// Custom field name and value used to tag visor images
 	VISOR_FIELD = "template_type"
 	VISOR_VALUE = "visor"
+	MO_TYPE_VM  = "VirtualMachine"
 
 	// Constants for supproted values for Flavor:Name
 	FlavorSmall   = "small"
@@ -1673,24 +1674,10 @@ func GetVmList(vm *VM, markedTemplate bool, markedVisor bool) (
 	var key int32
 	key = -1
 	if markedVisor {
-		fieldsManager, err := object.GetCustomFieldsManager(vm.client.Client)
+		key, err = addCustomField(vm, VISOR_FIELD, MO_TYPE_VM)
 		if err != nil {
 			return nil, err
 		}
-
-		key, err = fieldsManager.FindKey(vm.ctx, VISOR_FIELD)
-		if err != nil {
-			if err.Error() == "key name not found" {
-				_, err := fieldsManager.Add(vm.ctx, VISOR_FIELD, "VirtualMachine",
-					nil, nil)
-				if err != nil {
-					return nil, err
-				}
-			} else {
-				return nil, err
-			}
-		}
-		key, err = fieldsManager.FindKey(vm.ctx, VISOR_FIELD)
 	}
 
 	for _, vmProp := range vmPropList {
@@ -1706,7 +1693,11 @@ func GetVmList(vm *VM, markedTemplate bool, markedVisor bool) (
 			continue
 		}
 
-		if markedVisor && !isVisor(vmo, key) {
+		visorImage, err := isVisor(vmo, key)
+		if err != nil {
+			return nil, err
+		}
+		if markedVisor && !visorImage {
 			continue
 		}
 
@@ -1718,16 +1709,21 @@ func GetVmList(vm *VM, markedTemplate bool, markedVisor bool) (
 
 // isVisor: Returns true if template is Visor i.e. custom field is
 // set to appropriate value
-func isVisor(vmMo mo.VirtualMachine, key int32) bool {
+func isVisor(vmMo mo.VirtualMachine, key int32) (bool, error) {
 	values := vmMo.Summary.CustomValue
 	for _, value := range values {
 		if key == value.GetCustomFieldValue().Key {
-			if VISOR_VALUE == value.(*types.CustomFieldStringValue).Value {
-				return true
+			fieldValueStruct, ok := value.(*types.CustomFieldStringValue)
+			if !ok {
+				return false, fmt.Errorf("Custom field value of invalid type")
+			}
+			if VISOR_VALUE == fieldValueStruct.Value {
+				return true, nil
+
 			}
 		}
 	}
-	return false
+	return false, nil
 }
 
 // ConvertToTemplate : converts vm to vm template
@@ -1748,7 +1744,10 @@ func ConvertToTemplate(vm *VM) error {
 		return fmt.Errorf("error halting the VM: %v", err)
 	}
 
-	setCustomField(vm, vmMo, VISOR_FIELD, VISOR_VALUE)
+	err = setCustomField(vm, vmMo, VISOR_FIELD, MO_TYPE_VM, VISOR_VALUE)
+	if err != nil {
+		return fmt.Errorf("error in setting custom field: %v", err)
+	}
 
 	vmo := object.NewVirtualMachine(vm.client.Client, vmMo.Reference())
 	err = vmo.MarkAsTemplate(vm.ctx)

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -38,6 +38,10 @@ const (
 	SKIPTEMPLATE_OVERWRITE
 	SKIPTEMPLATE_USE
 
+	// Custom field name and value used to tag visor images
+	VISOR_FIELD = "template_type"
+	VISOR_VALUE = "visor"
+
 	// Constants for supproted values for Flavor:Name
 	FlavorSmall   = "small"
 	FlavorMedium  = "medium"
@@ -1624,8 +1628,9 @@ func getVmInfo(vmMo mo.VirtualMachine, vmPath string) map[string]interface{} {
 	}
 }
 
-// GetVmList : Returns the VMs/templates info in a dc/cluster/host
-func GetVmList(vm *VM, markedTemplate bool) ([]map[string]interface{}, error) {
+// GetVmList : Returns the VMs/templates/visor_templates info in a dc/cluster/host
+func GetVmList(vm *VM, markedTemplate bool, markedVisor bool) (
+	[]map[string]interface{}, error) {
 	var err error
 	vmPropList := make([]VmProperties, 0)
 	vmList := make([]map[string]interface{}, 0)
@@ -1663,6 +1668,31 @@ func GetVmList(vm *VM, markedTemplate bool) ([]map[string]interface{}, error) {
 	if vmPropList == nil {
 		return vmList, nil
 	}
+
+	// get key for VISOR_FIELD
+	var key int32
+	key = -1
+	if markedVisor {
+		fieldsManager, err := object.GetCustomFieldsManager(vm.client.Client)
+		if err != nil {
+			return nil, err
+		}
+
+		key, err = fieldsManager.FindKey(vm.ctx, VISOR_FIELD)
+		if err != nil {
+			if err.Error() == "key name not found" {
+				_, err := fieldsManager.Add(vm.ctx, VISOR_FIELD, "VirtualMachine",
+					nil, nil)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				return nil, err
+			}
+		}
+		key, err = fieldsManager.FindKey(vm.ctx, VISOR_FIELD)
+	}
+
 	for _, vmProp := range vmPropList {
 		vmo := vmProp.Properties
 		// Filter out the templates
@@ -1675,10 +1705,29 @@ func GetVmList(vm *VM, markedTemplate bool) ([]map[string]interface{}, error) {
 			!markedTemplate && vmo.Config.Template {
 			continue
 		}
+
+		if markedVisor && !isVisor(vmo, key) {
+			continue
+		}
+
 		vminfo := getVmInfo(vmo, vmProp.Name)
 		vmList = append(vmList, vminfo)
 	}
 	return vmList, nil
+}
+
+// isVisor: Returns true if template is Visor i.e. custom field is
+// set to appropriate value
+func isVisor(vmMo mo.VirtualMachine, key int32) bool {
+	values := vmMo.Summary.CustomValue
+	for _, value := range values {
+		if key == value.GetCustomFieldValue().Key {
+			if VISOR_VALUE == value.(*types.CustomFieldStringValue).Value {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // ConvertToTemplate : converts vm to vm template
@@ -1699,6 +1748,8 @@ func ConvertToTemplate(vm *VM) error {
 		return fmt.Errorf("error halting the VM: %v", err)
 	}
 
+	setCustomField(vm, vmMo, VISOR_FIELD, VISOR_VALUE)
+
 	vmo := object.NewVirtualMachine(vm.client.Client, vmMo.Reference())
 	err = vmo.MarkAsTemplate(vm.ctx)
 	if err != nil {
@@ -1706,6 +1757,7 @@ func ConvertToTemplate(vm *VM) error {
 			"error converting the uploaded VM to a template: %v",
 			err)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
**Jira Id**

[MRPHS-4596](https://apporbit.atlassian.net/browse/MRPHS-4596)

**Problem**
Currently there is no difference between visor templates(created through/for AppOrbit) and normal templates. There should be a way to identify visor templates and provide a get call for listing them.

**Resolution**
-  Updated ConvertToTemplate call to add custom field to visor which is created
- Updated GetVmList call to used custom field to distinguish visor templates from other templates and return only those when asked 

**Testing**
Unit tested ConvertToTemplate and GetVisorList functions with Halo dummy client. Logs attached.
[c3_4596.log](https://github.com/apporbit/libretto/files/1634450/c3_4596.log)
