### PR TITLE
MRPHS-4847 : Handle the case of create_vm when template is not present on the vcentre

### DIFF
--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -661,11 +661,8 @@ func (vm *VM) Provision() (err error) {
 				return fmt.Errorf("Unsupported value for SkipExisting parameter %d", vm.SkipExisting)
 			}
 		} else {
-			// Upload the template if  it does not exist. If it exists and SkipExisting is '2',
-			// use the existing template
-			if err := uploadTemplate(vm, dcMo, d); err != nil {
-				return err
-			}
+			return NewErrorObjectNotFound(errors.New(
+				"Template not found"), vm.Template.Name)
 		}
 		// Upload successful or the template was found with the SkipExisting flag set to true
 		usableDatastores = append(usableDatastores, d)


### PR DESCRIPTION
**Jira-id**

MRPHS-4847

**Problem**

If the template does not exist libretto tries to deploy the vm from ova file. If ova file is not present, error is thrown. The create vm should now create the template if it doesn't exist instead it should throw and error.

**Resolution**

Returning error in case the template does not exist while cloning vm.

**Unit Testing**

If template exist:
```
[root@my_machine client]# go run c3ntry_client.go createVm.json
Sending request:
action:"create_vms" args:"{\"cloud_type\":\"vsphere\",\"Datacenter\":\"C3 DataCenter\",\"Datastores\":[\"datastore2-ESXi13-2TB\"],\"Destination\":{\"DestinationName\":\"Cluster1\",\"DestinationType\":\"cluster\",\"HostSystem\":\"\"},\"Host\":\"dev-vcenter.gsintlab.com\",\"Insecure\":true,\"Networks\":[{\"description\":\"VM Network\",\"name\":\"VM Network\"}],\"OvaPathUrl\":\"<ova path url>\",\"Password\":\"password\",\"Username\":\"user@vsphere.local\",\"cloud_type\":\"vsphere\",\"cluster\":[{\"Disks\":[[{\"Controller\":\"scsi\",\"Provisioning\":\"thick\",\"size\":20},{\"Controller\":\"scsi\",\"Provisioning\":\"thick\",\"size\":20},{\"Controller\":\"scsi\",\"Provisioning\":\"thick\",\"size\":20},{\"Controller\":\"scsi\",\"provisioning\":\"thick\",\"size\":20}]],\"Flavor\":{\"cpu\":4,\"memory\":4096},\"SkipExisting\":2,\"Template\":{\"name\":\"visor_success\",\"instance_uuid\":\"\"},\"count\":1,\"gid\":0,\"name\":\"avnish\"}],\"cluster_name\":\"cluster-avnish\"}" id:"id-12"

2018/02/14 12:48:16 Received Response:
result:"{\"0\":[{\"gid\":\"0\",\"public_ipv4\":\"67.220.186.15\",\"index\":\"1\",\"vm_name\":\"avnish-0\",\"instance_id\":\"5009d5e1-79fb-5a29-93a6-18d8e20205e8\",\"vm_id\":\"vm-8273\"}]}" id:"id-12" progress:100

2018/02/14 12:48:16 Response String:
{"result":"{\"0\":[{\"gid\":\"0\",\"public_ipv4\":\"67.220.186.15\",\"index\":\"1\",\"vm_name\":\"avnish-0\",\"instance_id\":\"5009d5e1-79fb-5a29-93a6-18d8e20205e8\",\"vm_id\":\"vm-8273\"}]}","id":"id-12","progress":100}

2018/02/14 12:48:16 Breaking..
[root@my_machine client]#
```

If template doesn't exist:

```
[root@my_machine client]# go run c3ntry_client.go createVm.json
Sending request:
action:"create_vms" args:"{\"cloud_type\":\"vsphere\",\"Datacenter\":\"C3 DataCenter\",\"Datastores\":[\"datastore2-ESXi13-2TB\"],\"Destination\":{\"DestinationName\":\"Cluster1\",\"DestinationType\":\"cluster\",\"HostSystem\":\"\"},\"Host\":\"dev-vcenter.gsintlab.com\",\"Insecure\":true,\"Networks\":[{\"description\":\"VM Network\",\"name\":\"VM Network\"}],\"OvaPathUrl\":\"<ova path url>\",\"Password\":\"password\",\"Username\":\"user@vsphere.local\",\"cloud_type\":\"vsphere\",\"cluster\":[{\"Disks\":[[{\"Controller\":\"scsi\",\"Provisioning\":\"thick\",\"size\":20},{\"Controller\":\"scsi\",\"Provisioning\":\"thick\",\"size\":20},{\"Controller\":\"scsi\",\"Provisioning\":\"thick\",\"size\":20},{\"Controller\":\"scsi\",\"provisioning\":\"thick\",\"size\":20}]],\"Flavor\":{\"cpu\":4,\"memory\":4096},\"SkipExisting\":2,\"Template\":{\"name\":\"RHEL_7.2_TEMPLATE\",\"instance_uuid\":\"\"},\"count\":1,\"gid\":0,\"name\":\"avnish\"}],\"cluster_name\":\"cluster-avnish\"}" id:"id-12"

2018/02/14 12:41:24 Received Response:
result:"{\"0\":[{\"ret_str\":\"Could not retrieve the object 'RHEL_7.2_TEMPLATE' from the vSphere API: Template not found\",\"gid\":\"0\",\"index\":\"1\",\"vm_name\":\"avnish-0\",\"instance_id\":\"\",\"vm_id\":\"\",\"ret\":-1}]}" errcode:-1 id:"id-12" progress:-1

2018/02/14 12:41:24 Response String:
{"result":"{\"0\":[{\"ret_str\":\"Could not retrieve the object 'RHEL_7.2_TEMPLATE' from the vSphere API: Template not found\",\"gid\":\"0\",\"index\":\"1\",\"vm_name\":\"avnish-0\",\"instance_id\":\"\",\"vm_id\":\"\",\"ret\":-1}]}","errcode":-1,"id":"id-12","progress":-1}

2018/02/14 12:41:24 Breaking..
[root@my_machine client]#
```