### PR TITLE
MRPHS-4971: wait for v4 ips only in create_vms operation

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -1200,15 +1200,21 @@ var reconfigureVM = func(vm *VM, vmMo *mo.VirtualMachine) error {
 
 var waitForIP = func(vm *VM, vmMo *mo.VirtualMachine) error {
 	vmObj := object.NewVirtualMachine(vm.client.Client, vmMo.Reference())
-	ipString, err := vmObj.WaitForIP(vm.ctx)
+	// second parameter is to list v4 ips only and ignore v6 ips
+	ipMap, err := vmObj.WaitForNetIP(vm.ctx, true)
 	if err != nil {
 		return fmt.Errorf("failed to wait for VM to boot up: %v", err)
 	}
 
 	// Parse the IP to make sure tools was running
-	ip := net.ParseIP(ipString)
-	if ip == nil {
-		return fmt.Errorf("failed to parse the ip returned by the api: %s", ip)
+	for _, ips := range ipMap {
+		if len(ips) == 0 {
+			continue
+		}
+		ip := net.ParseIP(ips[0])
+		if ip == nil {
+			return fmt.Errorf("failed to parse the ip returned by the api: %s", ip)
+		}
 	}
 	return nil
 }

--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -1203,7 +1203,7 @@ var waitForIP = func(vm *VM, vmMo *mo.VirtualMachine) error {
 	// second parameter is to list v4 ips only and ignore v6 ips
 	ipMap, err := vmObj.WaitForNetIP(vm.ctx, true)
 	if err != nil {
-		return fmt.Errorf("failed to wait for VM to boot up: %v", err)
+		return fmt.Errorf("failed to wait for VM to get ips: %v", err)
 	}
 
 	// Parse the IP to make sure tools was running
@@ -1212,11 +1212,11 @@ var waitForIP = func(vm *VM, vmMo *mo.VirtualMachine) error {
 			continue
 		}
 		ip := net.ParseIP(ips[0])
-		if ip == nil {
-			return fmt.Errorf("failed to parse the ip returned by the api: %s", ip)
+		if ip != nil {
+			return nil
 		}
 	}
-	return nil
+	return fmt.Errorf("no valid ip assigned: %v", ipMap)
 }
 
 var halt = func(vm *VM) error {


### PR DESCRIPTION
**Jira-id**

MRPHS-4971

**Problem**

The ipv6 is returned as soon as it is assigned to the vm which is not used now. The create_Vm operation should wait for v4 ips and return it to the caller.

**Resolution**

wait for v4 ips only in create_vms operation

**Unit-testing**

Done. Tried Vm creation. The vm creation stuck even when ipv6 is assigned to the vm. The operation is stuck till v4 is not assigned to the vm.

**Ipv6 stuck case**

```
[root@my_machine test]# ./vsphereclient
1. CreateVMs           11. DeleteTemplate
2. DeleteVMs           12. GetDatacenterList
3. ShutDownVMs         13. GetDatastoreList
4. StartVMs            14. GetClusterList
5. StopVMs             15. GetHostList
6. ResetVMs            16. GetNetworkList
7. AddDisk             17. GetImageList
8. RemoveDisk          18. GetVmList
9. GetVMInfo           19. GetVisorList
10. ConvertToTemplate


        999. Default sequene "12 13 14 15 16 17 18 19 1 3 4 5 4 7 8 9 2"

Select one or sequence of method(s) to teist:
Ex. 1 <Enter> for CreateVM or 1 2 3 <Enter> for CreateVM followed by Delete and ShutDown VM

Your option: 1
Testing CreateVMs ...
WaitForIP :  fe80::6203:d31c:6233:8b54


^C
[root@my_machine test]#
```

**Create_vms success**

```
[root@my_machine test]# ./vsphereclient
1. CreateVMs           11. DeleteTemplate
2. DeleteVMs           12. GetDatacenterList
3. ShutDownVMs         13. GetDatastoreList
4. StartVMs            14. GetClusterList
5. StopVMs             15. GetHostList
6. ResetVMs            16. GetNetworkList
7. AddDisk             17. GetImageList
8. RemoveDisk          18. GetVmList
9. GetVMInfo           19. GetVisorList
10. ConvertToTemplate


        999. Default sequene "12 13 14 15 16 17 18 19 1 3 4 5 4 7 8 9 2"

Select one or sequence of method(s) to teist:
Ex. 1 <Enter> for CreateVM or 1 2 3 <Enter> for CreateVM followed by Delete and ShutDown VM

Your option: 1
Testing CreateVMs ...
WaitForIP :  192.168.1.57
WaitForNetIP :  map[00:50:56:89:07:ee:[192.168.1.57]]
WaitForIP :  192.168.1.57
WaitForNetIP :  map[00:50:56:89:07:ee:[192.168.1.57]]
CreateVMs SUCCESSFUL: VMs created and is powered on
{"0":[{"gid":"0","public_ipv4":"192.168.1.57","index":"1","vm_name":"avnish-0","instance_id":"5009f314-5f4b-7a9d-bb64-08c51bb856e9","vm_id":"vm-329"}]}

Sleeping for 5 seconds

[root@my_machine test]#
```