### PR TITLE
MRPHS-5099: Retrieve function in govmomi crashed if mor length is 0

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -870,6 +870,9 @@ func findResourcePoolListAtPath(vm *VM, path string, properties []string) ([]mo.
 		rpMor = append(rpMor, rp.Reference())
 	}
 
+	if len(rpMor) == 0 {
+		return allRpMo, nil
+	}
 	err = vm.collector.Retrieve(vm.ctx, rpMor, properties, &allRpMo)
 	if err != nil {
 		return nil, err
@@ -1109,6 +1112,9 @@ var getDatastoreForVm = func(vm *VM, vmMo *mo.VirtualMachine) ([]string,
 		err        error
 	)
 	dsMors := vmMo.Datastore
+	if len(dsMors) == 0 {
+		return datastores, nil
+	}
 	err = vm.collector.Retrieve(vm.ctx, dsMors, []string{"info"}, &dsMos)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -1960,6 +1966,9 @@ func getHostsLookup(vm *VM) (map[string]bool, error) {
 			return nil, err
 		}
 		// get the hosts in cluster
+		if len(crMo.Host) == 0 {
+			return hostsLookup, nil
+		}
 		err = vm.collector.Retrieve(vm.ctx, crMo.Host, []string{"name"},
 			&hsMos)
 		if err != nil {
@@ -2143,6 +2152,9 @@ func getSharedDatastoreInCluster(vm *VM, crMo *mo.ClusterComputeResource) (
 	)
 
 	dsList := make(map[types.ManagedObjectReference]int)
+	if len(crMo.Host) == 0 {
+		return dsMors, nil
+	}
 	err = vm.collector.Retrieve(vm.ctx, crMo.Host, []string{
 		"name", "datastore"}, &hsMos)
 	if err != nil {

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -1453,6 +1453,9 @@ func GetDcClusterList(vm *VM) ([]ClusterComputeResource, error) {
 	}
 	// get the cluster names
 	var allClustersMo []mo.ClusterComputeResource
+	if len(clustersMor) == 0 {
+		return dcClusterList, nil
+	}
 	err = vm.collector.Retrieve(vm.ctx, clustersMor, []string{"name",
 		"summary", "configuration", "host", "datastore", "network"},
 		&allClustersMo)
@@ -1560,6 +1563,9 @@ func GetDatacenterList(vm *VM) ([]map[string]string, error) {
 	}
 
 	// get the datacenter names
+	if len(dcMor) == 0 {
+		return dcList, nil
+	}
 	err = vm.collector.Retrieve(vm.ctx, dcMor, []string{"name"}, &allDcMo)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**Jira-id**

MRPHS-5099

**Problem**

Retrieve function in govmomi crashed if mor length is 0.

**Resolution**

Checked the length of mor and returned empty list if length of mor is 0.

**Unit-testing**

Done. Logs below:

```
[root@my_machine test]# ./vsphereclient
1. CreateVMs           11. DeleteTemplate
2. DeleteVMs           12. GetDatacenterList
3. ShutDownVMs         13. GetDatastoreList
4. StartVMs            14. GetClusterList
5. StopVMs             15. GetHostList
6. ResetVMs            16. GetNetworkList
7. AddDisk             17. GetImageList
8. RemoveDisk          18. GetVmList
9. GetVMInfo           19. GetVisorList
10. ConvertToTemplate


        999. Default sequene "12 13 14 15 16 17 18 19 1 3 4 5 4 7 8 9 2"

Select one or sequence of method(s) to teist:
Ex. 1 <Enter> for CreateVM or 1 2 3 <Enter> for CreateVM followed by Delete and ShutDown VM

Your option: 13
Testing GetDatastoreList ...
GetDatastoreList SUCCESSFUL:  []

Sleeping for 5 seconds

[root@my_machine test]#
```