### PR TITLE
MRPHS-5110: Getvmlist should return the vm info of the isntance uuids without datacenter

### DIFF
--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -1731,8 +1731,9 @@ func GetVmList(vm *VM, markedTemplate bool, markedVisor bool) (
 	defer vm.cancel()
 
 	if len(vm.InstanceUuids) != 0 {
-		searchFilter := VMSearchFilter{
-			SearchInDC: true,
+		searchFilter := VMSearchFilter{}
+		if vm.Datacenter != "" {
+			searchFilter.SearchInDC = true
 		}
 		for _, instanceUuid := range vm.InstanceUuids {
 			searchFilter.InstanceUuid = instanceUuid


### PR DESCRIPTION
**Jira-id**

MRPHS-5110

**Problem**

Getvmlist should return the vm info of the isntance uuids without datacenter.

**Resolution**

Changed the searchInDc filter to allow finding vms without datacenter.

**Unit-testing**

```
[root@my_machine test]# ./vsphereclient
1. CreateVMs           11. DeleteTemplate
2. DeleteVMs           12. GetDatacenterList
3. ShutDownVMs         13. GetDatastoreList
4. StartVMs            14. GetClusterList
5. StopVMs             15. GetHostList
6. ResetVMs            16. GetNetworkList
7. AddDisk             17. GetImageList
8. RemoveDisk          18. GetVmList
9. GetVMInfo           19. GetVisorList
10. ConvertToTemplate


        999. Default sequene "12 13 14 15 16 17 18 19 1 3 4 5 4 7 8 9 2"

Select one or sequence of method(s) to teist:
Ex. 1 <Enter> for CreateVM or 1 2 3 <Enter> for CreateVM followed by Delete and ShutDown VM

Your option: 17
Testing GetImageList ...
GetImageList SUCCESSFUL:  [{"cpu":1,"disks":[{"disk_file":"[datastore2-ESXi13-2TB] visor_template_2.2/visor_template_2.2.vmdk","name":"Hard disk 1","size":100}],"id":"vm-7350","instance_uuid":"5009d622-28c5-39e9-1674-249f0dd66050","ip_addresses":[],"memory":2048,"name":"visor_template_2.2","nic_info":[{"network_name":"","mac_address":"00:50:56:89:41:0f","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"","guest_full_name":"CentOS 4/5/6/7 (64-bit)","guest_id":"","hostname":""},"path":"visor_template_2.2","tool_status":false,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[datastore2] sqlclient-final/sqlclient-final.vmdk","name":"Hard disk 1","size":40}],"id":"vm-669","instance_uuid":"50092ba3-088c-a968-0d06-9a15a5aa45e1","ip_addresses":[],"memory":4096,"name":"Template-win-2008-sql_client-old","nic_info":[{"network_name":"","mac_address":"00:50:56:89:03:7f","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"","guest_full_name":"Microsoft Windows Server 2008 R2 (64-bit)","guest_id":"windows7Server64Guest","hostname":""},"path":"Template-win-2008-sql_client-old","tool_status":false,"tools_installed":false}]

Sleeping for 5 seconds

[root@my_machine test]#
```