### PR TITLE
MRPHS-5124: Support to send the vm info based on instance uuid without datacenter with get_vm_info call

### DIFF
--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -996,7 +996,18 @@ func (vm *VM) GetVMInfo() (VMInfo, error) {
 	}
 	defer vm.cancel()
 
-	vmMo, err := findVM(vm, getVMSearchFilter(vm.Name))
+	searchFilter := VMSearchFilter{}
+	if len(vm.InstanceUuids) != 0 {
+		searchFilter.InstanceUuid = vm.InstanceUuids[0]
+	} else {
+		searchFilter.Name = vm.Name
+	}
+	if vm.Datacenter != "" {
+		searchFilter.SearchInDC = true
+	} else {
+		searchFilter.SearchInDC = false
+	}
+	vmMo, err := findVM(vm, searchFilter)
 	if err != nil {
 		return vmInfo, err
 	}


### PR DESCRIPTION
**Jira-id**

MRPHS-5124

**Problem**

Support to send the vm info based on instance uuid without datacenter with get_vm_info call

**Resolution**

Added support to send the vm info based on instance uuid without datacenter with get_vm_info call

**Unit-testing**

```
[root@my_machine client]# go run c3ntry_client.go getVmInfo.json
Sending request:
action:"get_vm_info" args:"{\"cloud_type\":\"vsphere\",\"host\":\"dev-vcenter.gsintlab.com\",\"insecure\":true,\"username\":\"user@vsphere.local\",\"password\":\"password\",\"vms\":[{\"instance_uuid\":\"50097909-3c94-6704-9dc7-fe3bdae20f13\"}]}"

2018/02/23 03:34:07 Received Response:
result:"{\"VMs\":[{\"guestMemoryUsage\":81,\"overallCpuUsage\":32,\"toolsRunningStatus\":true,\"toolsInstalled\":true,\"maxMemoryUsage\":2048,\"maxCpuUsage\":6598,\"numCpu\":2,\"powerstate\":\"poweredOn\",\"memorySizeMB\":2048,\"disksInfo\":[{\"Size\":107374180000,\"Controller\":\"SCSI controller 0:0\",\"Provisioning\":\"thin\",\"Datastore\":\"\",\"DiskName\":\"\"}]}]}" progress:100

2018/02/23 03:34:07 Response String:
{"result":"{\"VMs\":[{\"guestMemoryUsage\":81,\"overallCpuUsage\":32,\"toolsRunningStatus\":true,\"toolsInstalled\":true,\"maxMemoryUsage\":2048,\"maxCpuUsage\":6598,\"numCpu\":2,\"powerstate\":\"poweredOn\",\"memorySizeMB\":2048,\"disksInfo\":[{\"Size\":107374180000,\"Controller\":\"SCSI controller 0:0\",\"Provisioning\":\"thin\",\"Datastore\":\"\",\"DiskName\":\"\"}]}]}","progress":100}

2018/02/23 03:34:07 Breaking..
[root@my_machine client]#





[root@my_machine client]# go run c3ntry_client.go getVmInfo.json
Sending request:
action:"get_vm_info" args:"{\"cloud_type\":\"vsphere\",\"host\":\"dev-vcenter.gsintlab.com\",\"insecure\":true,\"username\":\"user@vsphere.local\",\"password\":\"password\",\"vms\":[{\"name\":\"Avnish-1\",\"datacenter\":\"C3 DataCenter\"}]}"

2018/02/23 03:28:24 Received Response:
result:"{\"VMs\":[{\"datacenter\":\"C3 DataCenter\",\"guestMemoryUsage\":61,\"ipAddress\":[\"67.220.186.71\",\"fe80::f9f9:2242:37a2:6380\",\"67.220.186.60\",\"fe80::ce7e:3829:82c0:a9fd\",\"67.220.186.50\",\"fe80::250:56ff:fe89:5078\"],\"toolsRunningStatus\":true,\"toolsInstalled\":true,\"vMId\":\"vm-8475\",\"name\":\"Avnish-1\",\"maxMemoryUsage\":2048,\"maxCpuUsage\":6598,\"numCpu\":2,\"powerstate\":\"poweredOn\",\"memorySizeMB\":2048,\"disksInfo\":[{\"Size\":107374180000,\"Controller\":\"SCSI controller 0:0\",\"Provisioning\":\"thin\",\"Datastore\":\"\",\"DiskName\":\"\"}]}]}" progress:100

2018/02/23 03:28:24 Response String:
{"result":"{\"VMs\":[{\"datacenter\":\"C3 DataCenter\",\"guestMemoryUsage\":61,\"ipAddress\":[\"67.220.186.71\",\"fe80::f9f9:2242:37a2:6380\",\"67.220.186.60\",\"fe80::ce7e:3829:82c0:a9fd\",\"67.220.186.50\",\"fe80::250:56ff:fe89:5078\"],\"toolsRunningStatus\":true,\"toolsInstalled\":true,\"vMId\":\"vm-8475\",\"name\":\"Avnish-1\",\"maxMemoryUsage\":2048,\"maxCpuUsage\":6598,\"numCpu\":2,\"powerstate\":\"poweredOn\",\"memorySizeMB\":2048,\"disksInfo\":[{\"Size\":107374180000,\"Controller\":\"SCSI controller 0:0\",\"Provisioning\":\"thin\",\"Datastore\":\"\",\"DiskName\":\"\"}]}]}","progress":100}

2018/02/23 03:28:24 Breaking..
[root@my_machine client]#
```