### PR TITLE
MRPHS-5125 : C3ntry should not list the orphaned vms/templates in get list calls

### DIFF
--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -1783,6 +1783,10 @@ func GetVmList(vm *VM, markedTemplate bool, markedVisor bool) (
 
 	for _, vmProp := range vmPropList {
 		vmo := vmProp.Properties
+		// skipping if the vm/template is orphaned
+		if vmo.Runtime.ConnectionState == types.VirtualMachineConnectionStateOrphaned {
+			continue
+		}
 		// Filter out the templates
 		if vmo.Config == nil {
 			continue


### PR DESCRIPTION
**Jira-id**

MRPHS-5125

**Problem**

vm listing and template listing should not list the orphaned vms/templates 

**Resolution**

Skipping the vms/templates if it is orphaned

**Unit-testing**

```
[root@my_machine test]# ./vsphereclient
1. CreateVMs           12. GetDatacenterList
2. DeleteVMs           13. GetDatastoreList
3. ShutDownVMs         14. GetClusterList
4. StartVMs            15. GetHostList
5. StopVMs             16. GetNetworkList
6. ResetVMs            17. GetImageList
7. AddDisk             18. GetVmList
8. RemoveDisk          19. GetVisorList
9. GetVMInfo           20. ReconfigureVm
10. ConvertToTemplate   21. CreateVM
11. DeleteTemplate


        999. Default sequene "12 13 14 15 16 17 18 19 1 3 4 5 4 7 8 9 2"

Select one or sequence of method(s) to teist:
Ex. 1 <Enter> for CreateVM or 1 2 3 <Enter> for CreateVM followed by Delete and ShutDown VM

Your option: 18
Testing GetVmList ...
GetVmList SUCCESSFUL:  [{"cpu":8,"disks":[{"disk_file":"[datastore2-ESXi13-2TB] ak-master-test/ak-master-test.vmdk","name":"Hard disk 1","size":100},{"disk_file":"[datastore2-ESXi13-2TB] ak-master-test/ak-master-test_1.vmdk","name":"Hard disk 2","size":50}],"id":"vm-8406","instance_uuid":"50098b5d-3bb5-c1be-e440-b0c08ed16465","ip_addresses":["67.220.186.54","fe80::250:56ff:fe89:5df8"],"memory":40960,"name":"Discovered virtual machine/ak-master-test","nic_info":[{"network_name":"","mac_address":"00:50:56:89:5d:f8","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"otherGuestFamily","guest_full_name":"Linux 3.10.0-514.el7.x86_64 CentOS Linux release 7.3.1611 (Core) ","guest_id":"","hostname":"TEMPLATE_cENTOS-7.3"},"path":"Discovered virtual machine/ak-master-test","tool_status":true,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[datastore2-ESXi13-2TB] dhcp4.gsintlab.com/dhcp4.gsintlab.com.vmdk","name":"Hard disk 1","size":100}],"id":"vm-7347","instance_uuid":"50096de5-19ec-33ad-25c6-b086a531d83b","ip_addresses":["10.10.24.211","fe80::250:56ff:fe89:750b","67.220.186.67","fe80::250:56ff:fe89:591f"],"memory":2048,"name":"Discovered virtual machine/dhcp4.gsintlab.com","nic_info":[{"network_name":"","mac_address":"00:50:56:89:59:1f","nic_name":"Network adapter 1"},{"network_name":"","mac_address":"00:50:56:89:75:0b","nic_name":"Network adapter 2"}],"os_details":{"guest_family":"linuxGuest","guest_full_name":"CentOS 4/5/6/7 (64-bit)","guest_id":"centos64Guest","hostname":"localhost.localdomain"},"path":"Discovered virtual machine/dhcp4.gsintlab.com","tool_status":true,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[datastore2-ESXi13-2TB] sea-custom-0-1514550619/sea-custom-0-1514550619.vmdk","name":"Hard disk 1","size":50},{"disk_file":"[datastore2-ESXi13-2TB] sea-custom-0-1514550619/sea-custom-0-1514550619_1.vmdk","name":"Hard disk 2","size":100},{"disk_file":"[datastore2-ESXi13-2TB] sea-custom-0-1514550619/sea-custom-0-1514550619_2.vmdk","name":"Hard disk 3","size":10}],"id":"vm-7333","instance_uuid":"50093aba-6661-d4c3-9125-615e46f6604b","ip_addresses":["67.220.186.21"],"memory":4096,"name":"Discovered virtual machine/sea-custom-0-1514550619","nic_info":[{"network_name":"","mac_address":"00:50:56:89:4a:62","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"otherGuestFamily","guest_full_name":"Linux 3.10.0-514.el7.x86_64 CentOS Linux release 7.3.1611 (Core) ","guest_id":"","hostname":"ao-visor-50093aba-6661-d4c3-9125-615e46f6604b"},"path":"Discovered virtual machine/sea-custom-0-1514550619","tool_status":true,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[datastore2-ESXi13-2TB] sea-custom-0-1514547375/sea-custom-0-1514547375.vmdk","name":"Hard disk 1","size":50},{"disk_file":"[datastore2-ESXi13-2TB] sea-custom-0-1514547375/sea-custom-0-1514547375_1.vmdk","name":"Hard disk 2","size":100},{"disk_file":"[datastore2-ESXi13-2TB] sea-custom-0-1514547375/sea-custom-0-1514547375_2.vmdk","name":"Hard disk 3","size":10}],"id":"vm-7332","instance_uuid":"50095102-af31-e6ee-2704-83ddeac9e134","ip_addresses":["67.220.186.56"],"memory":2048,"name":"Discovered virtual machine/sea-custom-0-1514547375","nic_info":[{"network_name":"","mac_address":"00:50:56:89:55:5d","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"otherGuestFamily","guest_full_name":"Linux 3.10.0-514.el7.x86_64 CentOS Linux release 7.3.1611 (Core) ","guest_id":"","hostname":"ao-visor-50095102-af31-e6ee-2704-83ddeac9e134"},"path":"Discovered virtual machine/sea-custom-0-1514547375","tool_status":true,"tools_installed":true},{"cpu":1,"disks":[{"disk_file":"[datastore2-ESXi13-2TB] dhruv-vm1-1-20171222105115/dhruv-vm1-1-20171222105115.vmdk","name":"Hard disk 1","size":100}],"id":"vm-7322","instance_uuid":"50096af2-812d-5691-76b5-56857aa7c318","ip_addresses":[],"memory":1028,"name":"Discovered virtual machine/dhruv-vm1-1-20171222105115","nic_info":[{"network_name":"","mac_address":"00:50:56:89:08:c7","nic_name":"Network adapter 1"},{"network_name":"","mac_address":"00:50:56:89:48:ef","nic_name":"Network adapter 2"},{"network_name":"","mac_address":"00:50:56:89:35:0d","nic_name":"Network adapter 3"}],"os_details":{"guest_family":"","guest_full_name":"CentOS 4/5/6/7 (64-bit)","guest_id":"","hostname":""},"path":"Discovered virtual machine/dhruv-vm1-1-20171222105115","tool_status":false,"tools_installed":true},{"cpu":4,"disks":[{"disk_file":"[datastore2-ESXi13-2TB] dh-tier-2-vm2-0-20171115103047/dh-tier-2-vm2-0-20171115103047.vmdk","name":"Hard disk 1","size":100},{"disk_file":"[datastore2-ESXi13-2TB] dh-tier-2-vm2-0-20171115103047/dh-tier-2-vm2-0-20171115103047_1.vmdk","name":"Hard disk 2","size":12}],"id":"vm-7316","instance_uuid":"5009f0fa-adac-3e1b-6b4d-39840c87ea1f","ip_addresses":[],"memory":1024,"name":"Discovered virtual machine/dh-tier-2-vm2-0-20171115103047","nic_info":[{"network_name":"","mac_address":"00:50:56:89:2c:1a","nic_name":"Network adapter 1"},{"network_name":"","mac_address":"00:50:56:89:27:57","nic_name":"Network adapter 2"}],"os_details":{"guest_family":"","guest_full_name":"CentOS 4/5/6/7 (64-bit)","guest_id":"","hostname":""},"path":"Discovered virtual machine/dh-tier-2-vm2-0-20171115103047","tool_status":false,"tools_installed":false},{"cpu":1,"disks":[{"disk_file":"[datastore2-ESXi13-2TB] sea-test-0-1514466186/sea-test-0-1514466186.vmdk","name":"Hard disk 1","size":50},{"disk_file":"[datastore2-ESXi13-2TB] sea-test-0-1514466186/sea-test-0-1514466186_1.vmdk","name":"Hard disk 2","size":100},{"disk_file":"[datastore2-ESXi13-2TB] sea-test-0-1514466186/sea-test-0-1514466186_2.vmdk","name":"Hard disk 3","size":10}],"id":"vm-7330","instance_uuid":"500996b4-eb98-9c13-988b-55e48219e8b0","ip_addresses":["67.220.186.58"],"memory":2048,"name":"Discovered virtual machine/sea-test-0-1514466186","nic_info":[{"network_name":"","mac_address":"00:50:56:89:61:54","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"otherGuestFamily","guest_full_name":"Linux 3.10.0-514.el7.x86_64 CentOS Linux release 7.3.1611 (Core) ","guest_id":"","hostname":"ao-visor-500996b4-eb98-9c13-988b-55e48219e8b0"},"path":"Discovered virtual machine/sea-test-0-1514466186","tool_status":true,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[datastore2-ESXi13-2TB] Automation-offline-1/Automation-offline-1.vmdk","name":"Hard disk 1","size":48.828125},{"disk_file":"[datastore2-ESXi13-2TB] Automation-offline-1/Automation-offline-1_1.vmdk","name":"Hard disk 2","size":97.65625}],"id":"vm-7341","instance_uuid":"500961f4-9c41-4659-d69a-2d2c8c55abbc","ip_addresses":["10.10.24.200","67.220.186.63","fe80::cfe3:83bb:ab39:f5e4","10.10.24.219","fe80::b1e9:b37c:8feb:3f1e","10.10.24.112","fe80::8b23:d9e3:95bf:d49e","10.10.24.156","fe80::8233:a1fc:b53b:3a19","10.10.24.208","fe80::826c:1c6a:ac2e:150c","10.10.24.134","fe80::415f:c19b:d4e2:dcb0","10.10.24.57","fe80::f81c:2232:9b6d:70af","10.10.24.195","fe80::cc1a:b42:8251:1a67","10.10.24.209","fe80::901d:ce37:64d9:f8f6"],"memory":4096,"name":"Discovered virtual machine/Automation-offline-1","nic_info":[{"network_name":"","mac_address":"00:50:56:89:1a:05","nic_name":"Network adapter 1"},{"network_name":"","mac_address":"00:50:56:89:64:ec","nic_name":"Network adapter 2"},{"network_name":"","mac_address":"00:50:56:89:78:ed","nic_name":"Network adapter 3"},{"network_name":"","mac_address":"00:50:56:89:0e:09","nic_name":"Network adapter 4"},{"network_name":"","mac_address":"00:50:56:89:75:86","nic_name":"Network adapter 5"},{"network_name":"","mac_address":"00:50:56:89:47:81","nic_name":"Network adapter 6"},{"network_name":"","mac_address":"00:50:56:89:7b:29","nic_name":"Network adapter 7"},{"network_name":"","mac_address":"00:50:56:89:3b:ea","nic_name":"Network adapter 8"},{"network_name":"","mac_address":"00:50:56:89:6b:9b","nic_name":"Network adapter 9"},{"network_name":"","mac_address":"00:50:56:89:6f:a2","nic_name":"Network adapter 10"}],"os_details":{"guest_family":"otherGuestFamily","guest_full_name":"Linux 3.10.0-514.el7.x86_64 CentOS Linux release 7.3.1611 (Core) ","guest_id":"","hostname":"apporbit-visor"},"path":"Discovered virtual machine/Automation-offline-1","tool_status":true,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[datastore2-ESXi13-2TB] Avnish-1/Avnish-1.vmdk","name":"Hard disk 1","size":100}],"id":"vm-8475","instance_uuid":"50097909-3c94-6704-9dc7-fe3bdae20f13","ip_addresses":["67.220.186.71","fe80::f9f9:2242:37a2:6380","67.220.186.60","fe80::ce7e:3829:82c0:a9fd","67.220.186.50","fe80::250:56ff:fe89:5078"],"memory":2048,"name":"Avnish-1","nic_info":[{"network_name":"","mac_address":"00:50:56:89:50:78","nic_name":"Network adapter 1"},{"network_name":"","mac_address":"00:50:56:89:73:b1","nic_name":"Network adapter 2"},{"network_name":"","mac_address":"00:50:56:89:71:24","nic_name":"Network adapter 3"}],"os_details":{"guest_family":"otherGuestFamily","guest_full_name":"Linux 3.10.0-514.el7.x86_64 CentOS Linux release 7.3.1611 (Core) ","guest_id":"","hostname":"TEMPLATE_cENTOS-7.3"},"path":"Avnish-1","tool_status":true,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[datastore2-ESXi13-2TB] slave-0-1519375818/slave-0-1519375818.vmdk","name":"Hard disk 1","size":100},{"disk_file":"[datastore2-ESXi13-2TB] slave-0-1519375818/slave-0-1519375818_1.vmdk","name":"Hard disk 2","size":30},{"disk_file":"[datastore2-ESXi13-2TB] slave-0-1519375818/slave-0-1519375818_2.vmdk","name":"Hard disk 3","size":10}],"id":"vm-8490","instance_uuid":"5009542a-53b0-bf1d-47a6-db122db5818a","ip_addresses":["67.220.186.38","fe80::250:56ff:fe89:5943","10.244.1.0","172.17.0.1"],"memory":2048,"name":"slave-0-1519375818","nic_info":[{"network_name":"","mac_address":"00:50:56:89:59:43","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"otherGuestFamily","guest_full_name":"Linux 3.10.0-514.el7.x86_64 CentOS Linux release 7.3.1611 (Core) ","guest_id":"","hostname":"ao-visor-5009542a-53b0-bf1d-47a6-db122db5818a"},"path":"slave-0-1519375818","tool_status":true,"tools_installed":true},{"cpu":1,"disks":[{"disk_file":"[datastore2-ESXi13-2TB] prakash-ux-setup/prakash-ux-setup.vmdk","name":"Hard disk 1","size":100}],"id":"vm-8474","instance_uuid":"500901b1-1332-1d18-d671-c54c8ddf8073","ip_addresses":[],"memory":2048,"name":"prakash-ux-setup","nic_info":[{"network_name":"","mac_address":"00:50:56:89:12:c8","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"","guest_full_name":"CentOS 4/5/6/7 (64-bit)","guest_id":"","hostname":""},"path":"prakash-ux-setup","tool_status":false,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[datastore2-ESXi13-2TB] Master-0-1519296850/Master-0-1519296850.vmdk","name":"Hard disk 1","size":100},{"disk_file":"[datastore2-ESXi13-2TB] Master-0-1519296850/Master-0-1519296850_1.vmdk","name":"Hard disk 2","size":40},{"disk_file":"[datastore2-ESXi13-2TB] Master-0-1519296850/Master-0-1519296850_2.vmdk","name":"Hard disk 3","size":10}],"id":"vm-8461","instance_uuid":"50092ea5-b1c1-c0b6-6f25-044eec607b6a","ip_addresses":["67.220.186.55","fe80::250:56ff:fe89:e3a"],"memory":2048,"name":"Master-0-1519296850","nic_info":[{"network_name":"","mac_address":"00:50:56:89:0e:3a","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"otherGuestFamily","guest_full_name":"Linux 3.10.0-514.el7.x86_64 CentOS Linux release 7.3.1611 (Core) ","guest_id":"","hostname":"ao-visor-50092ea5-b1c1-c0b6-6f25-044eec607b6a"},"path":"Master-0-1519296850","tool_status":true,"tools_installed":true},{"cpu":4,"disks":[{"disk_file":"[datastore2-ESXi13-2TB] prakash-0-1519203486/prakash-0-1519203486.vmdk","name":"Hard disk 1","size":100},{"disk_file":"[datastore2-ESXi13-2TB] prakash-0-1519203486/prakash-0-1519203486_1.vmdk","name":"Hard disk 2","size":24},{"disk_file":"[datastore2-ESXi13-2TB] prakash-0-1519203486/prakash-0-1519203486_2.vmdk","name":"Hard disk 3","size":23}],"id":"vm-8444","instance_uuid":"500974ee-d4ef-306b-3aa9-94f9a8050921","ip_addresses":["10.244.1.1","fe80::48a7:28ff:fe2f:f866","fe80::54a2:fff:fe9a:ac90","fe80::f45e:88ff:fe3f:aeac","67.220.186.57","fe80::250:56ff:fe89:4b0","10.244.1.0","172.17.0.1"],"memory":4096,"name":"prakash-0-1519203486","nic_info":[{"network_name":"","mac_address":"00:50:56:89:04:b0","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"otherGuestFamily","guest_full_name":"Linux 3.10.0-514.el7.x86_64 CentOS Linux release 7.3.1611 (Core) ","guest_id":"","hostname":"ao-visor-500974ee-d4ef-306b-3aa9-94f9a8050921"},"path":"prakash-0-1519203486","tool_status":true,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[datastore2-ESXi13-2TB] Master-0-1519192234/Master-0-1519192234.vmdk","name":"Hard disk 1","size":100},{"disk_file":"[datastore2-ESXi13-2TB] Master-0-1519192234/Master-0-1519192234_1.vmdk","name":"Hard disk 2","size":20}],"id":"vm-8438","instance_uuid":"50093dfb-b98b-d4f5-92d4-5827419e1272","ip_addresses":["67.220.186.59","fe80::250:56ff:fe89:49c4"],"memory":2048,"name":"Master-0-1519192234","nic_info":[{"network_name":"","mac_address":"00:50:56:89:49:c4","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"otherGuestFamily","guest_full_name":"Linux 3.10.0-514.el7.x86_64 CentOS Linux release 7.3.1611 (Core) ","guest_id":"","hostname":"ao-visor-50093dfb-b98b-d4f5-92d4-5827419e1272"},"path":"Master-0-1519192234","tool_status":true,"tools_installed":true},{"cpu":4,"disks":[{"disk_file":"[datastore2-ESXi13-2TB] data-0-1519066648/data-0-1519066648.vmdk","name":"Hard disk 1","size":48.828125},{"disk_file":"[datastore2-ESXi13-2TB] data-0-1519066648/data-0-1519066648_1.vmdk","name":"Hard disk 2","size":97.65625}],"id":"vm-8395","instance_uuid":"50093b87-0f97-3bee-7a56-b33af12a6017","ip_addresses":["67.220.186.122"],"memory":4096,"name":"data-0-1519066648","nic_info":[{"network_name":"","mac_address":"00:50:56:89:18:4f","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"otherGuestFamily","guest_full_name":"Linux 3.10.0-514.el7.x86_64 CentOS Linux release 7.3.1611 (Core) ","guest_id":"","hostname":"data-0-1519066648"},"path":"data-0-1519066648","tool_status":true,"tools_installed":true},{"cpu":4,"disks":[{"disk_file":"[datastore2-ESXi13-2TB] tier-avnish_1-0-20180223085118/tier-avnish_1-0-20180223085118.vmdk","name":"Hard disk 1","size":100},{"disk_file":"[datastore2-ESXi13-2TB] tier-avnish_1-0-20180223085118/tier-avnish_1-0-20180223085118_1.vmdk","name":"Hard disk 2","size":50},{"disk_file":"[datastore2-ESXi13-2TB] tier-avnish_1-0-20180223085118/tier-avnish_1-0-20180223085118_2.vmdk","name":"Hard disk 3","size":20}],"id":"vm-8491","instance_uuid":"5009d5b6-4fa4-555a-0951-60aee7df9b62","ip_addresses":[],"memory":4096,"name":"tier-avnish_1-0-20180223085118","nic_info":[{"network_name":"","mac_address":"00:50:56:89:6b:1d","nic_name":"Network adapter 1"},{"network_name":"","mac_address":"00:50:56:89:06:53","nic_name":"Network adapter 2"}],"os_details":{"guest_family":"","guest_full_name":"CentOS 4/5/6/7 (64-bit)","guest_id":"","hostname":""},"path":"tier-avnish_1-0-20180223085118","tool_status":false,"tools_installed":false},{"cpu":2,"disks":[{"disk_file":"[datastore2-ESXi13-2TB] Master-0-1519375818/Master-0-1519375818.vmdk","name":"Hard disk 1","size":100},{"disk_file":"[datastore2-ESXi13-2TB] Master-0-1519375818/Master-0-1519375818_1.vmdk","name":"Hard disk 2","size":30},{"disk_file":"[datastore2-ESXi13-2TB] Master-0-1519375818/Master-0-1519375818_2.vmdk","name":"Hard disk 3","size":10}],"id":"vm-8489","instance_uuid":"50093029-fbab-722b-deb5-4b3f733dbfbb","ip_addresses":["10.244.0.1","fe80::e04d:a3ff:fe62:dd87","fe80::e48b:33ff:fe34:fe5e","fe80::c0dd:10ff:fe12:9f2f","67.220.186.29","fe80::250:56ff:fe89:1998","10.244.0.0","172.17.0.1"],"memory":2048,"name":"Master-0-1519375818","nic_info":[{"network_name":"","mac_address":"00:50:56:89:19:98","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"otherGuestFamily","guest_full_name":"Linux 3.10.0-514.el7.x86_64 CentOS Linux release 7.3.1611 (Core) ","guest_id":"","hostname":"ao-visor-50093029-fbab-722b-deb5-4b3f733dbfbb"},"path":"Master-0-1519375818","tool_status":true,"tools_installed":true},{"cpu":4,"disks":[{"disk_file":"[datastore2-ESXi13-2TB] prakash-node2/prakash-node2.vmdk","name":"Hard disk 1","size":100},{"disk_file":"[datastore2-ESXi13-2TB] prakash-node2/prakash-node2_1.vmdk","name":"Hard disk 2","size":100}],"id":"vm-8483","instance_uuid":"50096fcf-f108-567c-167c-3abf78301b0e","ip_addresses":[],"memory":4096,"name":"prakash-node2","nic_info":[{"network_name":"","mac_address":"00:50:56:89:12:36","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"","guest_full_name":"CentOS 4/5/6/7 (64-bit)","guest_id":"","hostname":""},"path":"prakash-node2","tool_status":false,"tools_installed":false},{"cpu":4,"disks":[{"disk_file":"[datastore2-ESXi13-2TB] Master-0-1518672940/Master-0-1518672940.vmdk","name":"Hard disk 1","size":48.828125},{"disk_file":"[datastore2-ESXi13-2TB] Master-0-1518672940/Master-0-1518672940_1.vmdk","name":"Hard disk 2","size":97.65625}],"id":"vm-8285","instance_uuid":"50098362-fc9b-8c04-4738-22c12938e13d","ip_addresses":["67.220.186.66"],"memory":4096,"name":"Master-0-1518672940","nic_info":[{"network_name":"","mac_address":"00:50:56:89:0f:b0","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"otherGuestFamily","guest_full_name":"Linux 3.10.0-514.el7.x86_64 CentOS Linux release 7.3.1611 (Core) ","guest_id":"","hostname":"ao-visor-50098362-fc9b-8c04-4738-22c12938e13d"},"path":"Master-0-1518672940","tool_status":true,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[datastore2-ESXi13-2TB] base_visor/base_visor.vmdk","name":"Hard disk 1","size":48.828125},{"disk_file":"[datastore2-ESXi13-2TB] base_visor/base_visor_1.vmdk","name":"Hard disk 2","size":97.65625}],"id":"vm-8390","instance_uuid":"5009523a-a763-2f10-5250-8ed4fb908ffb","ip_addresses":["67.220.186.10"],"memory":4096,"name":"base_visor","nic_info":[{"network_name":"","mac_address":"00:50:56:89:2f:1f","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"otherGuestFamily","guest_full_name":"Linux 3.10.0-514.el7.x86_64 CentOS Linux release 7.3.1611 (Core) ","guest_id":"","hostname":"apporbit-visor"},"path":"base_visor","tool_status":true,"tools_installed":true},{"cpu":4,"disks":[{"disk_file":"[datastore2-ESXi13-2TB] venkat-data-0-1518672940/venkat-data-0-1518672940.vmdk","name":"Hard disk 1","size":48.828125},{"disk_file":"[datastore2-ESXi13-2TB] venkat-data-0-1518672940/venkat-data-0-1518672940_1.vmdk","name":"Hard disk 2","size":97.65625},{"disk_file":"[datastore2-ESXi13-2TB] venkat-data-0-1518672940/venkat-data-0-1518672940_2.vmdk","name":"Hard disk 3","size":10}],"id":"vm-8286","instance_uuid":"500906ab-f303-50d6-d624-08b3dfdfbb3c","ip_addresses":["67.220.186.69"],"memory":4096,"name":"venkat-data-0-1518672940","nic_info":[{"network_name":"","mac_address":"00:50:56:89:2a:44","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"otherGuestFamily","guest_full_name":"Linux 3.10.0-514.el7.x86_64 CentOS Linux release 7.3.1611 (Core) ","guest_id":"","hostname":"apporbit-visor"},"path":"venkat-data-0-1518672940","tool_status":true,"tools_installed":true},{"cpu":4,"disks":[{"disk_file":"[datastore2-ESXi13-2TB] tier-avnish_2-0-20180223085118/tier-avnish_2-0-20180223085118.vmdk","name":"Hard disk 1","size":100},{"disk_file":"[datastore2-ESXi13-2TB] tier-avnish_2-0-20180223085118/tier-avnish_2-0-20180223085118_1.vmdk","name":"Hard disk 2","size":50},{"disk_file":"[datastore2-ESXi13-2TB] tier-avnish_2-0-20180223085118/tier-avnish_2-0-20180223085118_2.vmdk","name":"Hard disk 3","size":20}],"id":"vm-8492","instance_uuid":"50091689-57c5-6072-9523-bd4c75b9d2be","ip_addresses":[],"memory":4096,"name":"tier-avnish_2-0-20180223085118","nic_info":[{"network_name":"","mac_address":"00:50:56:89:2f:32","nic_name":"Network adapter 1"},{"network_name":"","mac_address":"00:50:56:89:79:92","nic_name":"Network adapter 2"}],"os_details":{"guest_family":"","guest_full_name":"CentOS 4/5/6/7 (64-bit)","guest_id":"","hostname":""},"path":"tier-avnish_2-0-20180223085118","tool_status":false,"tools_installed":false},{"cpu":4,"disks":[{"disk_file":"[datastore2-ESXi13-2TB] prakash-node1/prakash-node1.vmdk","name":"Hard disk 1","size":100},{"disk_file":"[datastore2-ESXi13-2TB] prakash-node1/prakash-node1_1.vmdk","name":"Hard disk 2","size":100}],"id":"vm-8481","instance_uuid":"5009a47e-99e5-58da-704f-7f424ec30a6e","ip_addresses":[],"memory":4096,"name":"prakash-node1","nic_info":[{"network_name":"","mac_address":"00:50:56:89:36:90","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"","guest_full_name":"CentOS 4/5/6/7 (64-bit)","guest_id":"","hostname":""},"path":"prakash-node1","tool_status":false,"tools_installed":false},{"cpu":4,"disks":[{"disk_file":"[datastore2-ESXi13-2TB] Master-0-1519203486/Master-0-1519203486.vmdk","name":"Hard disk 1","size":100},{"disk_file":"[datastore2-ESXi13-2TB] Master-0-1519203486/Master-0-1519203486_1.vmdk","name":"Hard disk 2","size":22},{"disk_file":"[datastore2-ESXi13-2TB] Master-0-1519203486/Master-0-1519203486_2.vmdk","name":"Hard disk 3","size":21}],"id":"vm-8443","instance_uuid":"500912b4-fa75-cdf1-7e6c-21dc941aa663","ip_addresses":["10.244.0.1","fe80::18ea:b4ff:fe60:2ff","fe80::b062:4dff:fe2c:3b7f","67.220.186.52","fe80::250:56ff:fe89:33be","10.244.0.0","172.17.0.1","fe80::b0c7:f8ff:fe7c:74c0"],"memory":4096,"name":"Master-0-1519203486","nic_info":[{"network_name":"","mac_address":"00:50:56:89:33:be","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"otherGuestFamily","guest_full_name":"Linux 3.10.0-514.el7.x86_64 CentOS Linux release 7.3.1611 (Core) ","guest_id":"","hostname":"ao-visor-500912b4-fa75-cdf1-7e6c-21dc941aa663"},"path":"Master-0-1519203486","tool_status":true,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[datastore1] manish-pool03-0-1519307757/manish-pool03-0-1519307757.vmdk","name":"Hard disk 1","size":100},{"disk_file":"[datastore1] manish-pool03-0-1519307757/manish-pool03-0-1519307757_1.vmdk","name":"Hard disk 2","size":50}],"id":"vm-8473","instance_uuid":"5009797e-74c9-5587-9c83-8b9277c0efd8","ip_addresses":["10.244.3.1","fe80::2075:9fff:fee6:630","67.220.185.219","fe80::250:56ff:fe89:b6c","10.244.3.0","172.17.0.1"],"memory":4096,"name":"manish-pool03-0-1519307757","nic_info":[{"network_name":"","mac_address":"00:50:56:89:0b:6c","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"otherGuestFamily","guest_full_name":"Linux 3.10.0-514.el7.x86_64 CentOS Linux release 7.3.1611 (Core) ","guest_id":"","hostname":"manish-pool03-0-1519307757"},"path":"manish-pool03-0-1519307757","tool_status":true,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[iSCSI-SAN-Storage1] Master-0-1519306204/Master-0-1519306204.vmdk","name":"Hard disk 1","size":100}],"id":"vm-8471","instance_uuid":"500950dc-6b51-e7cb-053d-5bb0f6e2d085","ip_addresses":["10.244.0.1","fe80::7c9b:10ff:fe8a:cf6d","fe80::f091:46ff:fe8d:9f67","fe80::d09c:55ff:fe2e:6fa6","67.220.185.218","fe80::250:56ff:fe89:272e","10.244.0.0","172.17.0.1"],"memory":4096,"name":"Master-0-1519306204","nic_info":[{"network_name":"","mac_address":"00:50:56:89:27:2e","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"otherGuestFamily","guest_full_name":"Linux 3.10.0-514.el7.x86_64 CentOS Linux release 7.3.1611 (Core) ","guest_id":"","hostname":"Master-0-1519306204"},"path":"Master-0-1519306204","tool_status":true,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[datastore1] manish-pool02-0-1519306204/manish-pool02-0-1519306204.vmdk","name":"Hard disk 1","size":100},{"disk_file":"[datastore1] manish-pool02-0-1519306204/manish-pool02-0-1519306204_1.vmdk","name":"Hard disk 2","size":50}],"id":"vm-8469","instance_uuid":"50091726-cb8f-96ad-3414-69d9af18831e","ip_addresses":["10.244.1.1","fe80::4c91:36ff:febc:6d24","67.220.185.220","fe80::250:56ff:fe89:eca","10.244.1.0","172.17.0.1"],"memory":4096,"name":"manish-pool02-0-1519306204","nic_info":[{"network_name":"","mac_address":"00:50:56:89:0e:ca","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"otherGuestFamily","guest_full_name":"Linux 3.10.0-514.el7.x86_64 CentOS Linux release 7.3.1611 (Core) ","guest_id":"","hostname":"manish-pool02-0-1519306204"},"path":"manish-pool02-0-1519306204","tool_status":true,"tools_installed":true},{"cpu":1,"disks":[{"disk_file":"[datastore2] MANISH_TEMPLATE_CentOS73/MANISH_TEMPLATE_CentOS73.vmdk","name":"Hard disk 1","size":100}],"id":"vm-8455","instance_uuid":"50097a94-c1f6-e50d-8278-e24509463e3c","ip_addresses":["67.220.190.44","fe80::e5e9:baad:5e58:a5e7"],"memory":2048,"name":"MANISH_TEMPLATE_CentOS73","nic_info":[{"network_name":"","mac_address":"00:50:56:89:05:af","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"otherGuestFamily","guest_full_name":"Linux 3.10.0-514.el7.x86_64 CentOS Linux release 7.3.1611 (Core) ","guest_id":"","hostname":"apporbit-visor-centos73"},"path":"MANISH_TEMPLATE_CentOS73","tool_status":true,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[datastore2] bhanu_vmimport_2/bhanu_vmimport_2-000011.vmdk","name":"Hard disk 1","size":15},{"disk_file":"[datastore2] bhanu_vmimport_2/bhanu_vmimport_2_1-000011.vmdk","name":"Hard disk 2","size":2},{"disk_file":"[datastore2] bhanu_vmimport_2/bhanu_vmimport_2_2-000011.vmdk","name":"Hard disk 3","size":2},{"disk_file":"[datastore2] bhanu_vmimport_2/bhanu_vmimport_2_3-000011.vmdk","name":"Hard disk 4","size":3},{"disk_file":"[datastore2] bhanu_vmimport_2/bhanu_vmimport_2_4-000011.vmdk","name":"Hard disk 5","size":3},{"disk_file":"[datastore2] bhanu_vmimport_2/bhanu_vmimport_2_5-000011.vmdk","name":"Hard disk 6","size":4}],"id":"vm-8369","instance_uuid":"5009b0be-ba0b-9a01-8c1f-41e92d0c6b2b","ip_addresses":["fe80::2c7a:4e57:53ed:574e","10.10.24.199","fe80::c52a:d941:bc:e70","67.220.185.216"],"memory":2048,"name":"bhanu_vmimport_2","nic_info":[{"network_name":"","mac_address":"00:50:56:89:04:66","nic_name":"Network adapter 1"},{"network_name":"","mac_address":"00:50:56:89:72:90","nic_name":"Network adapter 2"}],"os_details":{"guest_family":"windowsGuest","guest_full_name":"Microsoft Windows Server 2012 (64-bit)","guest_id":"windows8Server64Guest","hostname":"WIN-EA3QOLIJAFI"},"path":"bhanu_vmimport_2","tool_status":true,"tools_installed":true},{"cpu":1,"disks":[{"disk_file":"[datastore2] data-pool-0-1518195167/data-pool-0-1518195167.vmdk","name":"Hard disk 1","size":48.828125},{"disk_file":"[datastore2] data-pool-0-1518195167/data-pool-0-1518195167_1.vmdk","name":"Hard disk 2","size":97.65625}],"id":"vm-8145","instance_uuid":"500940c7-134f-9666-d62e-40a53229dbc2","ip_addresses":[],"memory":2048,"name":"data-pool-0-1518195167","nic_info":[{"network_name":"","mac_address":"00:50:56:89:68:50","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"otherGuestFamily","guest_full_name":"Linux 3.10.0-514.el7.x86_64 CentOS Linux release 7.3.1611 (Core) ","guest_id":"","hostname":"ao-visor-500940c7-134f-9666-d62e-40a53229dbc2"},"path":"data-pool-0-1518195167","tool_status":false,"tools_installed":true},{"cpu":1,"disks":[{"disk_file":"[datastore2] piyush test visor/piyush test visor.vmdk","name":"Hard disk 1","size":100}],"id":"vm-7768","instance_uuid":"50098244-90bb-4c8f-3f06-fba1616a5d38","ip_addresses":[],"memory":2048,"name":"piyush test visor","nic_info":[{"network_name":"","mac_address":"00:50:56:89:43:6b","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"linuxGuest","guest_full_name":"Red Hat Enterprise Linux 7 (64-bit)","guest_id":"rhel7_64Guest","hostname":"RESOURCE-FETCHER"},"path":"piyush test visor","tool_status":false,"tools_installed":true},{"cpu":1,"disks":[{"disk_file":"[datastore2] testVmforAnnaly/testVmforAnnaly.vmdk","name":"Hard disk 1","size":25},{"disk_file":"[datastore2] testVmforAnnaly/testVmforAnnaly_1.vmdk","name":"Hard disk 2","size":30}],"id":"vm-8287","instance_uuid":"5009c87e-add5-db7f-64b5-137248f5a1e1","ip_addresses":[],"memory":4096,"name":"testVmforAnnaly","nic_info":[{"network_name":"","mac_address":"00:50:56:89:37:7a","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"","guest_full_name":"Microsoft Windows Server 2012 (64-bit)","guest_id":"","hostname":""},"path":"testVmforAnnaly","tool_status":false,"tools_installed":false},{"cpu":2,"disks":[{"disk_file":"[datastore2] Db-Nativevm-Clone1/Db-Nativevm-Clone1.vmdk","name":"Hard disk 1","size":50},{"disk_file":"[datastore2] Db-Nativevm-Clone1/Db-Nativevm-Clone1_1.vmdk","name":"Hard disk 2","size":50}],"id":"vm-7187","instance_uuid":"50090613-2437-4471-4c17-027549a4eb39","ip_addresses":[],"memory":8192,"name":"Db-Nativevm-Clone1","nic_info":[{"network_name":"","mac_address":"00:50:56:89:06:2a","nic_name":"Network adapter 1"},{"network_name":"","mac_address":"00:50:56:89:35:55","nic_name":"Network adapter 2"}],"os_details":{"guest_family":"","guest_full_name":"Microsoft Windows Server 2012 (64-bit)","guest_id":"","hostname":""},"path":"Db-Nativevm-Clone1","tool_status":false,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[datastore2] Native-VM-IIS-Cloned/Native-VM-IIS-Cloned.vmdk","name":"Hard disk 1","size":50},{"disk_file":"[datastore2] Native-VM-IIS-Cloned/Native-VM-IIS-Cloned_1.vmdk","name":"Hard disk 2","size":50}],"id":"vm-6925","instance_uuid":"5009cd41-ad4e-497c-ebb4-be66d83c7910","ip_addresses":[],"memory":8192,"name":"Native-VM-IIS-Cloned","nic_info":[{"network_name":"","mac_address":"00:50:56:89:1f:1b","nic_name":"Network adapter 1"},{"network_name":"","mac_address":"00:50:56:89:75:33","nic_name":"Network adapter 2"}],"os_details":{"guest_family":"","guest_full_name":"Microsoft Windows Server 2012 (64-bit)","guest_id":"","hostname":""},"path":"Native-VM-IIS-Cloned","tool_status":false,"tools_installed":false},{"cpu":2,"disks":[{"disk_file":"[datastore2] Native-VM-DB-Cloned/Native-VM-DB-Cloned.vmdk","name":"Hard disk 1","size":50},{"disk_file":"[datastore2] Native-VM-DB-Cloned/Native-VM-DB-Cloned_1.vmdk","name":"Hard disk 2","size":50}],"id":"vm-6923","instance_uuid":"5009f92d-4be8-ccde-5943-d42a4fea0a8e","ip_addresses":[],"memory":8192,"name":"Native-VM-DB-Cloned","nic_info":[{"network_name":"","mac_address":"00:50:56:89:19:04","nic_name":"Network adapter 1"},{"network_name":"","mac_address":"00:50:56:89:51:93","nic_name":"Network adapter 2"}],"os_details":{"guest_family":"","guest_full_name":"Microsoft Windows Server 2012 (64-bit)","guest_id":"","hostname":""},"path":"Native-VM-DB-Cloned","tool_status":false,"tools_installed":false},{"cpu":1,"disks":[{"disk_file":"[datastore2] teir1-vm1-0-20171219121109/teir1-vm1-0-20171219121109.vmdk","name":"Hard disk 1","size":100}],"id":"vm-6912","instance_uuid":"50093349-d834-ffba-9f41-ca82fa7018e5","ip_addresses":[],"memory":2048,"name":"teir1-vm1-0-20171219121109","nic_info":[{"network_name":"","mac_address":"00:50:56:89:78:c7","nic_name":"Network adapter 1"},{"network_name":"","mac_address":"00:50:56:89:08:df","nic_name":"Network adapter 2"}],"os_details":{"guest_family":"linuxGuest","guest_full_name":"Red Hat Enterprise Linux 7 (64-bit)","guest_id":"rhel7_64Guest","hostname":"ESOURCE-RHEL-7.2"},"path":"teir1-vm1-0-20171219121109","tool_status":false,"tools_installed":true},{"cpu":1,"disks":[{"disk_file":"[datastore2] kjsf/kjsf-000001.vmdk","name":"Hard disk 1","size":100}],"id":"vm-7349","instance_uuid":"5009876c-13d0-b70e-7f57-377c4a9ad191","ip_addresses":["10.10.24.147","fe80::250:56ff:fe89:1ea8","67.220.185.206","fe80::250:56ff:fe89:396"],"memory":2048,"name":"kjsf","nic_info":[{"network_name":"","mac_address":"00:50:56:89:03:96","nic_name":"Network adapter 1"},{"network_name":"","mac_address":"00:50:56:89:1e:a8","nic_name":"Network adapter 2"}],"os_details":{"guest_family":"linuxGuest","guest_full_name":"Red Hat Enterprise Linux 7 (64-bit)","guest_id":"rhel7_64Guest","hostname":"RESOURCE-FETCHER"},"path":"kjsf","tool_status":true,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[datastore2] IIS-nativeVM/IIS-nativeVM-000001.vmdk","name":"Hard disk 1","size":50},{"disk_file":"[datastore2] IIS-nativeVM/IIS-nativeVM_1-000001.vmdk","name":"Hard disk 2","size":50}],"id":"vm-6417","instance_uuid":"5009c965-61be-0817-7ca6-75a583c56dfb","ip_addresses":[],"memory":8192,"name":"IIS-nativeVM","nic_info":[{"network_name":"","mac_address":"00:50:56:89:19:d0","nic_name":"Network adapter 1"},{"network_name":"","mac_address":"00:50:56:89:32:89","nic_name":"Network adapter 2"}],"os_details":{"guest_family":"","guest_full_name":"Microsoft Windows Server 2012 (64-bit)","guest_id":"","hostname":""},"path":"IIS-nativeVM","tool_status":false,"tools_installed":false},{"cpu":2,"disks":[{"disk_file":"[datastore2] DB-nativeVM/DB-nativeVM-000001.vmdk","name":"Hard disk 1","size":50},{"disk_file":"[datastore2] DB-nativeVM/DB-nativeVM_1-000001.vmdk","name":"Hard disk 2","size":50}],"id":"vm-6414","instance_uuid":"50095be8-1fad-2c38-b4be-578407b13f1e","ip_addresses":[],"memory":8192,"name":"DB-nativeVM","nic_info":[{"network_name":"","mac_address":"00:50:56:89:0e:69","nic_name":"Network adapter 1"},{"network_name":"","mac_address":"00:50:56:89:13:87","nic_name":"Network adapter 2"}],"os_details":{"guest_family":"windowsGuest","guest_full_name":"Microsoft Windows Server 2012 (64-bit)","guest_id":"windows8Server64Guest","hostname":"WIN-5I0LJ169G88.nvm.gsintlab.com"},"path":"DB-nativeVM","tool_status":false,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[datastore1] AD-VM-NATIVEVM/AD-VM-NATIVEVM.vmdk","name":"Hard disk 1","size":50},{"disk_file":"[datastore1] AD-VM-NATIVEVM/AD-VM-NATIVEVM_1.vmdk","name":"Hard disk 2","size":10}],"id":"vm-6427","instance_uuid":"5009ef2e-57eb-bfa7-e7b8-9d07b92dbdd2","ip_addresses":[],"memory":6000,"name":"AD-VM-NATIVEVM","nic_info":[{"network_name":"","mac_address":"00:50:56:89:01:14","nic_name":"Network adapter 1"},{"network_name":"","mac_address":"00:50:56:89:42:4f","nic_name":"Network adapter 2"}],"os_details":{"guest_family":"","guest_full_name":"Microsoft Windows Server 2012 (64-bit)","guest_id":"","hostname":""},"path":"AD-VM-NATIVEVM","tool_status":false,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[datastore2] SAURABH-AO-PROXY/SAURABH-AO-PROXY-000001.vmdk","name":"Hard disk 1","size":50}],"id":"vm-637","instance_uuid":"5009c71f-e024-f62f-8e75-f8768724330d","ip_addresses":["10.10.24.115","fe80::250:56ff:fe89:4598","fe80::a450:c8ff:fea2:1cf4","67.220.190.38","fe80::250:56ff:fe89:6833","172.17.0.1","fe80::42:50ff:feb1:a33b"],"memory":4096,"name":"Bhanu-AO-PROXY-FINAL","nic_info":[{"network_name":"","mac_address":"00:50:56:89:68:33","nic_name":"Network adapter 1"},{"network_name":"","mac_address":"00:50:56:89:45:98","nic_name":"Network adapter 2"}],"os_details":{"guest_family":"linuxGuest","guest_full_name":"CentOS 4/5/6/7 (64-bit)","guest_id":"centos64Guest","hostname":"AOPROXY-MACHINE"},"path":"Bhanu-AO-PROXY-FINAL","tool_status":true,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[datastore2] GATEWAY-VM/GATEWAY-VM.vmdk","name":"Hard disk 1","size":40},{"disk_file":"[datastore1] GATEWAY-VM/GATEWAY-VM_1.vmdk","name":"Hard disk 2","size":10}],"id":"vm-6416","instance_uuid":"50098dab-fc87-da8a-b081-18bf9787bf18","ip_addresses":[],"memory":6000,"name":"GATEWAY-VM","nic_info":[{"network_name":"","mac_address":"00:50:56:89:74:b3","nic_name":"Network adapter 1"},{"network_name":"","mac_address":"00:50:56:89:43:d4","nic_name":"Network adapter 2"}],"os_details":{"guest_family":"","guest_full_name":"Microsoft Windows Server 2012 (64-bit)","guest_id":"","hostname":""},"path":"GATEWAY-VM","tool_status":false,"tools_installed":true},{"cpu":2,"disks":[],"id":"vm-6218","instance_uuid":"5009aa8f-e47a-ed67-ffac-9496c9badf81","ip_addresses":[],"memory":4096,"name":"ashishtestsqlserver","nic_info":[{"network_name":"","mac_address":"00:50:56:89:2d:fd","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"windowsGuest","guest_full_name":"Microsoft Windows Server 2008 R2 (64-bit)","guest_id":"windows7Server64Guest","hostname":"WIN-G299Q5Q9AP8"},"path":"ashishtestsqlserver","tool_status":false,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[datastore1] manish-pool03-1-1519307757/manish-pool03-1-1519307757.vmdk","name":"Hard disk 1","size":100},{"disk_file":"[datastore1] manish-pool03-1-1519307757/manish-pool03-1-1519307757_1.vmdk","name":"Hard disk 2","size":50}],"id":"vm-8472","instance_uuid":"5009034f-7c0d-c99c-07bb-16cda4d8c0f0","ip_addresses":["10.244.4.1","fe80::d42f:cfff:fe14:3f4a","67.220.185.221","fe80::250:56ff:fe89:1a0a","10.244.4.0","172.17.0.1"],"memory":4096,"name":"manish-pool03-1-1519307757","nic_info":[{"network_name":"","mac_address":"00:50:56:89:1a:0a","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"otherGuestFamily","guest_full_name":"Linux 3.10.0-514.el7.x86_64 CentOS Linux release 7.3.1611 (Core) ","guest_id":"","hostname":"manish-pool03-1-1519307757"},"path":"manish-pool03-1-1519307757","tool_status":true,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[datastore1] hemanshu-ao-visor-feb-09/hemanshu-ao-visor-feb-09.vmdk","name":"Hard disk 1","size":48.828125},{"disk_file":"[datastore1] hemanshu-ao-visor-feb-09/hemanshu-ao-visor-feb-09_1.vmdk","name":"Hard disk 2","size":97.65625}],"id":"vm-8136","instance_uuid":"50091dda-5d39-708e-d607-28b5167e6366","ip_addresses":[],"memory":4096,"name":"hemanshu-ao-visor-feb-09","nic_info":[{"network_name":"","mac_address":"00:50:56:89:09:c3","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"otherGuestFamily","guest_full_name":"Linux 3.10.0-514.el7.x86_64 CentOS Linux release 7.3.1611 (Core) ","guest_id":"","hostname":"apporbit-visor"},"path":"hemanshu-ao-visor-feb-09","tool_status":false,"tools_installed":true},{"cpu":1,"disks":[{"disk_file":"[datastore2] app-app-1-20171105080157/app-app-1-20171105080157.vmdk","name":"Hard disk 1","size":100}],"id":"vm-5690","instance_uuid":"5009dad0-7661-4c25-4bd5-f0d2e83d5618","ip_addresses":["67.220.185.202","fe80::250:56ff:fe89:4cf4","67.220.185.205","fe80::250:56ff:fe89:3049"],"memory":2048,"name":"app-app-1-20171105080157","nic_info":[{"network_name":"","mac_address":"00:50:56:89:30:49","nic_name":"Network adapter 1"},{"network_name":"","mac_address":"00:50:56:89:4c:f4","nic_name":"Network adapter 2"}],"os_details":{"guest_family":"linuxGuest","guest_full_name":"Red Hat Enterprise Linux 7 (64-bit)","guest_id":"rhel7_64Guest","hostname":"ESOURCE-RHEL-7.2"},"path":"app-app-1-20171105080157","tool_status":true,"tools_installed":true},{"cpu":1,"disks":[{"disk_file":"[datastore2] app-app-0-20171105080157/app-app-0-20171105080157.vmdk","name":"Hard disk 1","size":100}],"id":"vm-5689","instance_uuid":"5009e12e-ce10-abe3-230d-478f742c4546","ip_addresses":[],"memory":2048,"name":"app-app-0-20171105080157","nic_info":[{"network_name":"","mac_address":"00:50:56:89:01:f7","nic_name":"Network adapter 1"},{"network_name":"","mac_address":"00:50:56:89:4e:05","nic_name":"Network adapter 2"}],"os_details":{"guest_family":"linuxGuest","guest_full_name":"Red Hat Enterprise Linux 7 (64-bit)","guest_id":"rhel7_64Guest","hostname":"ESOURCE-RHEL-7.2"},"path":"app-app-0-20171105080157","tool_status":false,"tools_installed":true},{"cpu":1,"disks":[{"disk_file":"[datastore2] AO-PROXY-5.0/AO-PROXY-5.0.vmdk","name":"Hard disk 1","size":40}],"id":"vm-5537","instance_uuid":"5009e659-4776-d011-7678-a1f1cfe4bd3a","ip_addresses":[],"memory":2048,"name":"AO-PROXY-5.0","nic_info":[{"network_name":"","mac_address":"00:50:56:89:10:8c","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"","guest_full_name":"CentOS 4/5/6/7 (64-bit)","guest_id":"","hostname":""},"path":"AO-PROXY-5.0","tool_status":false,"tools_installed":false},{"cpu":1,"disks":[{"disk_file":"[datastore2] autocluster/autocluster.vmdk","name":"Hard disk 1","size":100},{"disk_file":"[datastore2] autocluster/autocluster_1.vmdk","name":"Hard disk 2","size":100}],"id":"vm-5472","instance_uuid":"5009e83f-8565-f6a2-6878-6bca3a6fc392","ip_addresses":[],"memory":4096,"name":"autocluster","nic_info":[{"network_name":"","mac_address":"00:50:56:89:66:66","nic_name":"Network adapter 2"}],"os_details":{"guest_family":"","guest_full_name":"CentOS 4/5/6/7 (64-bit)","guest_id":"","hostname":""},"path":"autocluster","tool_status":false,"tools_installed":false},{"cpu":2,"disks":[{"disk_file":"[datastore2] AWS SMS Connector/AWS SMS Connector.vmdk","name":"Hard disk 1","size":21.000977},{"disk_file":"[datastore2] AWS SMS Connector/AWS SMS Connector_1.vmdk","name":"Hard disk 2","size":16},{"disk_file":"[datastore2] AWS SMS Connector/AWS SMS Connector_2.vmdk","name":"Hard disk 3","size":8},{"disk_file":"[datastore2] AWS SMS Connector/AWS SMS Connector_3.vmdk","name":"Hard disk 4","size":4},{"disk_file":"[datastore2] AWS SMS Connector/AWS SMS Connector_4.vmdk","name":"Hard disk 5","size":250}],"id":"vm-6767","instance_uuid":"5009b6aa-cf1d-4705-c7d5-68e443ac05fe","ip_addresses":[],"memory":8192,"name":"AWS SMS Connector","nic_info":[{"network_name":"","mac_address":"00:50:56:89:04:6a","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"","guest_full_name":"FreeBSD (64-bit)","guest_id":"","hostname":""},"path":"AWS SMS Connector","tool_status":false,"tools_installed":true},{"cpu":1,"disks":[{"disk_file":"[datastore2] user_psun_vm-0-0/user_psun_vm-0-0.vmdk","name":"Hard disk 1","size":10}],"id":"vm-5207","instance_uuid":"5009511a-1ee3-bcf2-41c9-417ec8e6bd1a","ip_addresses":[],"memory":1024,"name":"user_psun_vm-0-0","nic_info":[{"network_name":"","mac_address":"00:50:56:89:69:01","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"linuxGuest","guest_full_name":"Ubuntu Linux (64-bit)","guest_id":"ubuntu64Guest","hostname":"ubuntuguest"},"path":"user_psun_vm-0-0","tool_status":false,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[datastore2] NVM-Gateway/NVM-Gateway.vmdk","name":"Hard disk 1","size":50},{"disk_file":"[datastore2] NVM-Gateway/NVM-Gateway_1.vmdk","name":"Hard disk 2","size":40}],"id":"vm-6511","instance_uuid":"500909ca-dd2e-ad7d-9aec-bf2bf82be309","ip_addresses":[],"memory":4096,"name":"NVM-Gateway","nic_info":[{"network_name":"","mac_address":"00:50:56:89:4c:65","nic_name":"Network adapter 1"},{"network_name":"","mac_address":"00:50:56:89:00:f2","nic_name":"Network adapter 2"}],"os_details":{"guest_family":"","guest_full_name":"Microsoft Windows Server 2012 (64-bit)","guest_id":"","hostname":""},"path":"NVM-Gateway","tool_status":false,"tools_installed":true},{"cpu":4,"disks":[{"disk_file":"[datastore2] centos-7.2-provider/centos-7.2-provider.vmdk","name":"Hard disk 1","size":100},{"disk_file":"[datastore2] centos-7.2-provider/centos-7.2-provider_1.vmdk","name":"Hard disk 2","size":100}],"id":"vm-5156","instance_uuid":"50096411-9d78-7ec5-c087-0665a4a23114","ip_addresses":[],"memory":8192,"name":"centos-7.2-provider","nic_info":[{"network_name":"","mac_address":"00:50:56:89:5f:cd","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"linuxGuest","guest_full_name":"CentOS 4/5/6/7 (64-bit)","guest_id":"centos64Guest","hostname":"centos-7.2.template"},"path":"centos-7.2-provider","tool_status":false,"tools_installed":true},{"cpu":4,"disks":[{"disk_file":"[datastore2] visor_prakash/visor_prakash.vmdk","name":"Hard disk 1","size":100},{"disk_file":"[datastore2] visor_prakash/visor_prakash_1.vmdk","name":"Hard disk 2","size":100}],"id":"vm-7963","instance_uuid":"50095c1c-330c-04e8-c67d-1938e8d7ee69","ip_addresses":["fe80::e430:6dff:fe56:b105","fe80::90fb:dbff:fe27:a3ec","fe80::c0d8:dfff:fe9c:200d","fe80::341c:1bff:fe75:e7ef","fe80::8c79:f9ff:fef3:3d6","fe80::d037:78ff:fe5b:2c95","fe80::181a:f9ff:fe19:e358","fe80::8df:ffff:fe5f:c667","67.220.185.212","fe80::250:56ff:fe89:62ca","fe80::1cb8:faff:fe65:3768","fe80::381b:21ff:fe39:59d6","fe80::a478:87ff:fe3b:325c","fe80::48:8dff:fed7:ad59","fe80::f4bd:feff:fea8:8d6a","fe80::c12:b5ff:fec6:1bdf","172.17.0.1","fe80::42:5bff:fe58:8c9f"],"memory":8192,"name":"visor_prakash","nic_info":[{"network_name":"","mac_address":"00:50:56:89:62:ca","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"linuxGuest","guest_full_name":"CentOS 4/5/6/7 (64-bit)","guest_id":"centos64Guest","hostname":"centos-7.2.template"},"path":"visor_prakash","tool_status":true,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[datastore2] sqlserver/sqlserver.vmdk","name":"Hard disk 1","size":40},{"disk_file":"[datastore2] sqlserver/ad-sqlserver-2005_2005.vmdk","name":"Hard disk 2","size":3}],"id":"vm-736","instance_uuid":"5009a827-e603-b648-6c6e-2ae7c1370c13","ip_addresses":[],"memory":4096,"name":"ad-sqlserver-2005","nic_info":[{"network_name":"","mac_address":"00:50:56:89:03:17","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"windowsGuest","guest_full_name":"Microsoft Windows Server 2008 R2 (64-bit)","guest_id":"windows7Server64Guest","hostname":"ad-sqlserver-1.windows-slave.gsintlab.com"},"path":"ad-sqlserver-2005","tool_status":false,"tools_installed":true},{"cpu":8,"disks":[{"disk_file":"[datastore2] vcenter-5.5/vcenter-5.5-000001.vmdk","name":"Hard disk 1","size":50}],"id":"vm-3490","instance_uuid":"50094386-08b5-8432-a45d-3d3297fb53dd","ip_addresses":[],"memory":8192,"name":"vcenter-5.5","nic_info":[{"network_name":"","mac_address":"00:50:56:89:4f:3c","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"windowsGuest","guest_full_name":"Microsoft Windows Server 2012 (64-bit)","guest_id":"windows8Server64Guest","hostname":"WIN-EV389PNHHUP"},"path":"vcenter-5.5","tool_status":false,"tools_installed":true},{"cpu":1,"disks":[{"disk_file":"[datastore2] single-vm-psun-0/single-vm-psun-0-000002.vmdk","name":"Hard disk 1","size":10}],"id":"vm-5843","instance_uuid":"5009e0ac-a73d-5cb2-2029-eab8fdbc3ca7","ip_addresses":[],"memory":1024,"name":"single-vm-psun-0","nic_info":[{"network_name":"","mac_address":"00:50:56:89:4c:1d","nic_name":"Network adapter 1"},{"network_name":"","mac_address":"00:50:56:89:71:78","nic_name":"Network adapter 2"},{"network_name":"","mac_address":"00:50:56:89:15:f0","nic_name":"Network adapter 3"}],"os_details":{"guest_family":"linuxGuest","guest_full_name":"Ubuntu Linux (64-bit)","guest_id":"ubuntu64Guest","hostname":"ubuntuguest"},"path":"single-vm-psun-0","tool_status":false,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[datastore2] sumeet-macvtap-test2/sumeet-macvtap-test2.vmdk","name":"Hard disk 1","size":100}],"id":"vm-4984","instance_uuid":"500903e9-1aac-13fc-75ae-34f32d8e668e","ip_addresses":[],"memory":4096,"name":"sumeet-macvtap-test2","nic_info":[{"network_name":"","mac_address":"00:50:56:89:3c:60","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"linuxGuest","guest_full_name":"CentOS 4/5/6/7 (64-bit)","guest_id":"centos64Guest","hostname":"centos-7.2.template"},"path":"sumeet-macvtap-test2","tool_status":false,"tools_installed":true},{"cpu":1,"disks":[{"disk_file":"[datastore2] AO-PROXY-5.0-1/AO-PROXY-5.0-1.vmdk","name":"Hard disk 1","size":40}],"id":"vm-2786","instance_uuid":"5009d446-9d37-aaab-c09d-658b44b9e12a","ip_addresses":[],"memory":2048,"name":"AO-PROXY-5.0-1","nic_info":[{"network_name":"","mac_address":"00:50:56:89:1f:e0","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"","guest_full_name":"CentOS 4/5/6/7 (64-bit)","guest_id":"","hostname":""},"path":"AO-PROXY-5.0-1","tool_status":false,"tools_installed":false},{"cpu":2,"disks":[{"disk_file":"[datastore2] Auto-vmimport/Auto-vmimport-000001.vmdk","name":"Hard disk 1","size":10},{"disk_file":"[datastore2] Auto-vmimport/Auto-vmimport_1-000001.vmdk","name":"Hard disk 2","size":2}],"id":"vm-5011","instance_uuid":"5009f60d-177d-91ee-14f4-baf145390e26","ip_addresses":[],"memory":4096,"name":"Auto-vmimport","nic_info":[{"network_name":"","mac_address":"00:50:56:89:27:f6","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"","guest_full_name":"Microsoft Windows Server 2008 R2 (64-bit)","guest_id":"","hostname":""},"path":"Auto-vmimport","tool_status":false,"tools_installed":false},{"cpu":2,"disks":[{"disk_file":"[datastore2] test image/test image.vmdk","name":"Hard disk 1","size":100}],"id":"vm-7798","instance_uuid":"5009db9e-8b77-1dfa-0409-bc38393183b6","ip_addresses":[],"memory":8192,"name":"test image","nic_info":[{"network_name":"","mac_address":"00:50:56:89:4f:21","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"otherGuestFamily","guest_full_name":"Linux 3.10.0-514.el7.x86_64 CentOS Linux release 7.3.1611 (Core) ","guest_id":"","hostname":"centos"},"path":"test image","tool_status":false,"tools_installed":true},{"cpu":1,"disks":[{"disk_file":"[datastore2] data-pool-0-1518181681/data-pool-0-1518181681.vmdk","name":"Hard disk 1","size":48.828125},{"disk_file":"[datastore2] data-pool-0-1518181681/data-pool-0-1518181681_1.vmdk","name":"Hard disk 2","size":97.65625}],"id":"vm-8140","instance_uuid":"50091ce3-b3a8-5b69-d112-8efa94b3e48e","ip_addresses":[],"memory":2048,"name":"data-pool-0-1518181681","nic_info":[{"network_name":"","mac_address":"00:50:56:89:1f:f1","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"otherGuestFamily","guest_full_name":"Linux 3.10.0-514.el7.x86_64 CentOS Linux release 7.3.1611 (Core) ","guest_id":"","hostname":"ao-visor-50091ce3-b3a8-5b69-d112-8efa94b3e48e"},"path":"data-pool-0-1518181681","tool_status":false,"tools_installed":true},{"cpu":1,"disks":[{"disk_file":"[datastore2] single-vm-psun-1/single-vm-psun-1.vmdk","name":"Hard disk 1","size":10}],"id":"vm-5842","instance_uuid":"5009f445-3aa8-09c1-500e-9c7e771e53e9","ip_addresses":[],"memory":1024,"name":"single-vm-psun-1","nic_info":[{"network_name":"","mac_address":"00:50:56:89:09:d5","nic_name":"Network adapter 1"},{"network_name":"","mac_address":"00:50:56:89:52:79","nic_name":"Network adapter 2"},{"network_name":"","mac_address":"00:50:56:89:41:a7","nic_name":"Network adapter 3"}],"os_details":{"guest_family":"linuxGuest","guest_full_name":"Ubuntu Linux (64-bit)","guest_id":"ubuntu64Guest","hostname":"ubuntuguest"},"path":"single-vm-psun-1","tool_status":false,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[datastore2] dhcp2.gsintlab.com/dhcp2.gsintlab.com.vmdk","name":"Hard disk 1","size":50}],"id":"vm-2828","instance_uuid":"50099eb5-be93-ba57-f468-8cf4e1cd5d04","ip_addresses":[],"memory":2048,"name":"dhcp2.gsintlab.com","nic_info":[{"network_name":"","mac_address":"00:50:56:89:38:e5","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"","guest_full_name":"CentOS 4/5/6/7 (64-bit)","guest_id":"","hostname":""},"path":"dhcp2.gsintlab.com","tool_status":false,"tools_installed":false},{"cpu":2,"disks":[{"disk_file":"[datastore2] infranetes-base-datastore2/infranetes-base-datastore2-000001.vmdk","name":"Hard disk 1","size":10}],"id":"vm-354","instance_uuid":"5009b31a-b7f4-1bae-cdc1-0f5c1c37a6d9","ip_addresses":[],"memory":1024,"name":"infranetes-base-datastore2","nic_info":[{"network_name":"","mac_address":"00:50:56:89:3a:bb","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"","guest_full_name":"Other 3.x or later Linux (64-bit)","guest_id":"other3xLinux64Guest","hostname":"ubuntuguest"},"path":"infranetes-base-datastore2","tool_status":false,"tools_installed":true},{"cpu":8,"disks":[{"disk_file":"[datastore2] windows-vcenter/windows-vcenter-000002.vmdk","name":"Hard disk 1","size":200}],"id":"vm-14","instance_uuid":"525217ec-c711-df05-6422-8127a9552ce8","ip_addresses":["fe80::1d9d:7926:7d8b:9d13","10.10.24.96","fe80::4542:4f30:99ee:269c","209.205.216.11"],"memory":16384,"name":"windows-vcenter","nic_info":[{"network_name":"","mac_address":"00:0c:29:89:d1:0b","nic_name":"Network adapter 1"},{"network_name":"","mac_address":"00:50:56:be:5a:85","nic_name":"Network adapter 2"}],"os_details":{"guest_family":"windowsGuest","guest_full_name":"Microsoft Windows Server 2012 (64-bit)","guest_id":"windows8Server64Guest","hostname":"WIN-KHDEJ6OV91O"},"path":"windows-vcenter","tool_status":true,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[datastore2] vm3-win-2012-4disks/vm3-win-2012-4disks-000002.vmdk","name":"Hard disk 1","size":20},{"disk_file":"[datastore2] vm3-win-2012-4disks/vm3-win-2012-4disks_5-000002.vmdk","name":"Hard disk 2","size":15},{"disk_file":"[datastore2] vm3-win-2012-4disks/vm3-win-2012-4disks_6-000002.vmdk","name":"Hard disk 3","size":12},{"disk_file":"[datastore2] vm3-win-2012-4disks/vm3-win-2012-4disks_7-000002.vmdk","name":"Hard disk 4","size":10}],"id":"vm-412","instance_uuid":"50097493-09b7-06ed-5327-9507c631f526","ip_addresses":[],"memory":4096,"name":"vm-ENTRY_win12.folder-mount-4disks","nic_info":[{"network_name":"","mac_address":"00:50:56:89:51:f0","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"windowsGuest","guest_full_name":"Microsoft Windows Server 2012 (64-bit)","guest_id":"windows8Server64Guest","hostname":"testvm1.apporbitlab.local"},"path":"vm-ENTRY_win12.folder-mount-4disks","tool_status":false,"tools_installed":true},{"cpu":2,"disks":[{"disk_file":"[datastore2] sqlclient-domain/sqlclient-domain-000001.vmdk","name":"Hard disk 1","size":40},{"disk_file":"[datastore2] sqlclient-domain/sqlclient-domain_1-000001.vmdk","name":"Hard disk 2","size":1},{"disk_file":"[datastore2] sqlclient-domain/sqlclient-domain_2-000001.vmdk","name":"Hard disk 3","size":2},{"disk_file":"[datastore2] sqlclient-domain/sqlclient-domain_3-000001.vmdk","name":"Hard disk 4","size":3},{"disk_file":"[datastore2] sqlclient-domain/sqlclient-domain_4-000001.vmdk","name":"Hard disk 5","size":4},{"disk_file":"[datastore2] sqlclient-domain/sqlclient-domain_5-000001.vmdk","name":"Hard disk 6","size":5},{"disk_file":"[datastore2] sqlclient-domain/sqlclient-domain_6-000001.vmdk","name":"Hard disk 7","size":6}],"id":"vm-1116","instance_uuid":"5009bb41-9bee-8228-7384-c9906205b0b8","ip_addresses":[],"memory":4096,"name":"ad-sqlclient-2005","nic_info":[{"network_name":"","mac_address":"00:50:56:89:1c:b0","nic_name":"Network adapter 1"}],"os_details":{"guest_family":"windowsGuest","guest_full_name":"Microsoft Windows Server 2008 R2 (64-bit)","guest_id":"windows7Server64Guest","hostname":"ad-sqlclient-1.windows-slave.gsintlab.com"},"path":"ad-sqlclient-2005","tool_status":false,"tools_installed":true}]

Sleeping for 5 seconds

[root@my_machine test]#
```