### PR TITLE
MRPHS-5219: VM nodes were not deleted sometimes when incorrect guest state is returned

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -1740,6 +1740,16 @@ func getState(vm *VM) (state string, err error) {
 	return vmMo.Guest.GuestState, nil
 }
 
+func getPowerState(vm *VM) (state string, err error) {
+	// Get a reference to the datacenter with host and vm folders populated
+	vmMo, err := findVM(vm, getVMSearchFilter(vm.Name))
+	if err != nil {
+		return "", lvm.ErrVMInfoFailed
+	}
+
+	return fmt.Sprintf("%s", vmMo.Runtime.PowerState), nil
+}
+
 // answerQuestion checks to see if there are currently pending questions on the
 // VM which prevent further actions. If so, it automatically responds to the
 // question based on the the vm.QuestionResponses map. If there is a problem


### PR DESCRIPTION
**Jira Id**

[MRPHS-5219](https://apporbit.atlassian.net/browse/MRPHS-5219)

**Problem**
VM nodes were not deleted when delete operation was called on failed cluster. But this is not related to failed cluster case and happens when sometimes vshpere api returns incorrect guest state "notRunning" while vm is actually in "running" state. Because of this destroy call fails.

**Resolution**
To be more conservative now checking VM PowerState also along with GuestState. So that in case if GuestState is incorrect, PowerState could hold destroy call until vm is actually poweredOff.

Returning GuestState and PowerState at the time of destroy call for error case, to debug such case in future.

**Testing**
Unit tested deleteVMs call on happy path and explicitly introducing incorrect guest state with Halo client. Logs attached.
[c3_deleteVMs.log](https://github.com/apporbit/libretto/files/1780744/c3_deleteVMs.log)
