### PR TITLE
MRPHS-5077: Reconfigure vm - Support to add/remove networks attached to a vm, updated cpu/memory of a powered off vm.

### DIFF
--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -787,8 +787,6 @@ func (vm *VM) RemoveDisk() error {
 
 // dvsFromMOID locates a DVS by its managed object reference ID.
 func dvsFromMOID(vm *VM, id string) (*object.VmwareDistributedVirtualSwitch, error) {
-	// finder := find.NewFinder(client.Client, false)
-
 	ref := types.ManagedObjectReference{
 		Type:  "VmwareDistributedVirtualSwitch",
 		Value: id,
@@ -820,7 +818,10 @@ func dvsFromUUID(vm *VM, uuid string) (*object.VmwareDistributedVirtualSwitch,
 		err = fmt.Errorf("error querying dvs by uuid: %v", err)
 		return nil, err
 	}
-
+	if resp == nil {
+		return nil, errors.New("error querying dvs by uuid: " +
+			"nil response returned")
+	}
 	return dvsFromMOID(vm, resp.Returnval.Reference().Value)
 }
 
@@ -864,6 +865,9 @@ func getDvpGroupName(vm *VM,
 // getNicInfo returns the nic info of this VM.
 func getNicInfo(vm *VM, vmMo mo.VirtualMachine) []VirtualEthernetCard {
 	nicInfo := make([]VirtualEthernetCard, 0)
+	if vmMo.Config == nil {
+		return nicInfo
+	}
 	for _, dev := range vmMo.Config.Hardware.Device {
 		var nic VirtualEthernetCard
 		c, ok := dev.(types.BaseVirtualEthernetCard)
@@ -1956,7 +1960,7 @@ func (vm *VM) ValidateAuth() error {
 	return nil
 }
 
-// ReconfigureVm: reconfigure's vm CPU, memory, network
+// Reconfigure: reconfigures vm CPU, memory, network
 func (vm *VM) Reconfigure() error {
 	var (
 		err error

--- a/virtualmachine/vsphere/vm_test.go
+++ b/virtualmachine/vsphere/vm_test.go
@@ -462,9 +462,9 @@ func TestFindComputeResourcePropertyError(t *testing.T) {
 }
 
 func TestCreateNetworkMapping(t *testing.T) {
-	nwMap := map[string]string{
-		"nw1": "mapping1",
-		"nw3": "mapping2",
+	nws := []Network{
+		Network{Name: "mapping1"},
+		Network{Name: "mapping2"},
 	}
 	networkMors := []types.ManagedObjectReference{{Type: "Network"}, {Type: "Network"}}
 	callCount := 1 //First call
@@ -485,7 +485,7 @@ func TestCreateNetworkMapping(t *testing.T) {
 		Password:  "test",
 		collector: c,
 	}
-	mappings, err := createNetworkMapping(vm, nwMap, networkMors)
+	mappings, _, err := createNetworkMapping(vm, nws, networkMors)
 	if err != nil {
 		t.Fatalf("Expected to a nil err. Got: %s", err)
 	}
@@ -495,9 +495,9 @@ func TestCreateNetworkMapping(t *testing.T) {
 }
 
 func TestCreateNetworkMappingPropertyFailed(t *testing.T) {
-	nwMap := map[string]string{
-		"nw1": "mapping1",
-		"nw3": "mapping2",
+	nws := []Network{
+		Network{Name: "mapping1"},
+		Network{Name: "mapping2"},
 	}
 	networkMors := []types.ManagedObjectReference{{Type: "Network"}, {Type: "Network"}}
 	c := mockCollector{}
@@ -511,16 +511,16 @@ func TestCreateNetworkMappingPropertyFailed(t *testing.T) {
 		Password:  "test",
 		collector: c,
 	}
-	_, err := createNetworkMapping(vm, nwMap, networkMors)
+	_, _, err := createNetworkMapping(vm, nws, networkMors)
 	if err.Error() != expectedError {
 		t.Fatalf("Expected to get err %s, got: %s", expectedError, err)
 	}
 }
 
 func TestCreateObjectError(t *testing.T) {
-	nwMap := map[string]string{
-		"nw1": "mapping1",
-		"nw3": "mapping2",
+	nws := []Network{
+		Network{Name: "mapping1"},
+		Network{Name: "mapping2"},
 	}
 	networkMors := []types.ManagedObjectReference{{Type: "Network"}, {Type: "Network"}}
 	c := mockCollector{}
@@ -535,7 +535,7 @@ func TestCreateObjectError(t *testing.T) {
 		Password:  "test",
 		collector: c,
 	}
-	_, err := createNetworkMapping(vm, nwMap, networkMors)
+	_, _, err := createNetworkMapping(vm, nws, networkMors)
 	if _, ok := err.(ErrorObjectNotFound); !ok {
 		t.Fatalf("Expected to get an ErrorObjectNotFound got: %s", err)
 	}


### PR DESCRIPTION
**Jira-id**

MRPHS-5077

**Problem**

Support for reconfiguring vm is not there. Support to add/remove networks attached to a vm, updated cpu/memory of a poweredoff vm.
Fetch the name of the distributed port group in get_vm_info call.

**Solution**

Added support to add/remove network and update cpu/memory of the vm.
Fetched the name of the distributed port group in get_vm_info call.

**Unit-testing**

Tried Fetching info of vm having distributed port group attached.

Distributed pg name : DistributedPrivateNetwork
```
[root@my_machine test]# ./vsphereclient
1. CreateVMs           12. GetDatacenterList
2. DeleteVMs           13. GetDatastoreList
3. ShutDownVMs         14. GetClusterList
4. StartVMs            15. GetHostList
5. StopVMs             16. GetNetworkList
6. ResetVMs            17. GetImageList
7. AddDisk             18. GetVmList
8. RemoveDisk          19. GetVisorList
9. GetVMInfo           20. ReconfigureCompute
10. ConvertToTemplate   21. CreateVM
11. DeleteTemplate


        999. Default sequene "12 13 14 15 16 17 18 19 1 3 4 5 4 7 8 9 2"

Select one or sequence of method(s) to test:
Ex. 1 <Enter> for CreateVM or 1 2 3 <Enter> for CreateVM followed by Delete and ShutDown VM

Your option: 9
Testing GetVMInfo ...
GetVMInfo SUCCESSFUL:  {"VMId":"vm-8896","InstanceId":"5009d03b-f38a-4407-b161-38d704dfb942","IpAddress":[],"ToolsRunningStatus":false,"ToolsInstalled":true,"OverallCpuUsage":0,"GuestMemoryUsage":0,"MaxCpuUsage":3503,"MaxMemoryUsage":2048,"NumCpu":1,"PowerState":"poweredOff","MemorySizeMB":2048,"DisksInfo":[{"size":1.0737418e+11,"controller":"SCSI controller 0:0","provisioning":"thin","disk_file":"[datastore2] avnish-reconfigure/avnish-reconfigure.vmdk"}],"nic_info":[{"network_name":"VM Network","mac_address":"00:50:56:89:48:e0","nic_name":"Network adapter 1","device_key":4000},{"network_name":"Private Network","mac_address":"00:50:56:89:18:0b","nic_name":"Network adapter 2","device_key":4001}]}

Sleeping for 5 seconds

[root@my_machine test]#



After removing port group (Private Network) and VM Network and changing cpu - 2 memory - 8092

input - [root@my_machine test]# cat reconfigure_vm.json
{"Host":"dev-vcenter.gsintlab.com","Username":"user@vsphere.local","Password":"password","Insecure":true,"Datacenter":"developer-lab","networks":[{"name":"Private Network","operation":"remove","device_key":4001},{"name":"VM Network","operation":"remove","device_key":4000},{"name":"Private Network"}],"Name":"avnish-reconfigure","flavor":{"cpu":2,"memory":8092}}
[root@my_machine test]#

[root@my_machine test]# ./vsphereclient
1. CreateVMs           12. GetDatacenterList
2. DeleteVMs           13. GetDatastoreList
3. ShutDownVMs         14. GetClusterList
4. StartVMs            15. GetHostList
5. StopVMs             16. GetNetworkList
6. ResetVMs            17. GetImageList
7. AddDisk             18. GetVmList
8. RemoveDisk          19. GetVisorList
9. GetVMInfo           20. ReconfigureCompute
10. ConvertToTemplate   21. CreateVM
11. DeleteTemplate


        999. Default sequene "12 13 14 15 16 17 18 19 1 3 4 5 4 7 8 9 2"

Select one or sequence of method(s) to test:
Ex. 1 <Enter> for CreateVM or 1 2 3 <Enter> for CreateVM followed by Delete and ShutDown VM

Your option: 20
Testing ReconfigureCompute ...
ReconfigureCompute SUCCESSFUL

Sleeping for 5 seconds

[root@my_machine test]#



[root@my_machine test]# ./vsphereclient
1. CreateVMs           12. GetDatacenterList
2. DeleteVMs           13. GetDatastoreList
3. ShutDownVMs         14. GetClusterList
4. StartVMs            15. GetHostList
5. StopVMs             16. GetNetworkList
6. ResetVMs            17. GetImageList
7. AddDisk             18. GetVmList
8. RemoveDisk          19. GetVisorList
9. GetVMInfo           20. ReconfigureCompute
10. ConvertToTemplate   21. CreateVM
11. DeleteTemplate


        999. Default sequene "12 13 14 15 16 17 18 19 1 3 4 5 4 7 8 9 2"

Select one or sequence of method(s) to test:
Ex. 1 <Enter> for CreateVM or 1 2 3 <Enter> for CreateVM followed by Delete and ShutDown VM

Your option: 9
Testing GetVMInfo ...
GetVMInfo SUCCESSFUL:  {"VMId":"vm-8897","InstanceId":"500902a6-f66e-e6b4-b309-a2a308d0661a","IpAddress":[],"ToolsRunningStatus":false,"ToolsInstalled":true,"OverallCpuUsage":0,"GuestMemoryUsage":0,"MaxCpuUsage":0,"MaxMemoryUsage":0,"NumCpu":2,"PowerState":"poweredOff","MemorySizeMB":8092,"DisksInfo":[{"size":1.0737418e+11,"controller":"SCSI controller 0:0","provisioning":"thin","disk_file":"[datastore2] avnish-reconfigure/avnish-reconfigure.vmdk"}],"nic_info":[{"network_name":"Private Network","mac_address":"00:50:56:89:23:ec","nic_name":"Network adapter 1","device_key":4000}]}

Sleeping for 5 seconds

[root@my_machine test]#```