### PR TITLE
MRPHS-5422: Visor Creation failed as govmomi returned wrong state

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -2200,3 +2200,28 @@ func getSharedDatastoreInCluster(vm *VM, crMo *mo.ClusterComputeResource) (
 	}
 	return dsMors, nil
 }
+
+// existActiveTasks: returns true if any active tasks done on vm are active
+func isTaskInProgress(vm *VM, vmMo *mo.VirtualMachine) bool {
+	var (
+		taskMo mo.Task
+		err    error
+	)
+	for _, task := range vmMo.RecentTask {
+		err = vm.collector.RetrieveOne(vm.ctx, task, []string{
+			"info"}, &taskMo)
+		if err != nil {
+			continue
+		}
+		switch taskMo.Info.State {
+		// available states queued, running, success, error
+		case types.TaskInfoStateQueued, types.TaskInfoStateRunning:
+			return false
+		}
+	}
+	return true
+}
+
+// waitForTaskToFinish: returns true if any active tasks done on vm are active
+func waitForTasksToFinish(vm *VM, vmMo *mo.VirtualMachine) {
+}

--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -2222,6 +2222,11 @@ func isTaskInProgress(vm *VM, vmMo *mo.VirtualMachine) bool {
 	return true
 }
 
-// waitForTaskToFinish: returns true if any active tasks done on vm are active
-func waitForTasksToFinish(vm *VM, vmMo *mo.VirtualMachine) {
+// waitForTasksToFinish: waits for any active tasks on vm
+func waitForTasksToFinish(vm *VM, tasks []types.ManagedObjectReference) {
+	// wait for tasks to finish
+	for _, task := range tasks {
+		tObj := object.NewTask(vm.client.Client, task)
+		tObj.Wait(vm.ctx)
+	}
 }

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -870,11 +870,7 @@ func (vm *VM) Destroy() (err error) {
 	for powerState != "poweredOff" {
 		// Only possible states are poweredOff, poweredOn, suspended
 		if !isTaskInProgress(vm, vmMo) {
-			// wait for tasks to finish
-			for _, task := range vmMo.RecentTask {
-				tObj := object.NewTask(vm.client.Client, task)
-				tObj.Wait(vm.ctx)
-			}
+			waitForTasksToFinish(vm, vmMo.RecentTask)
 		} else {
 			e := halt(vm)
 			if e != nil {


### PR DESCRIPTION
**Jira-id**

MRPHS-5422

**Problem**

Visor Creation failed as govmomi returned wrong state. The vm is not deleted as the guest state of the vm is not returned correctly from api.  And delete vm failed as the vm is in poweredOn state.

```
>>> vm.guest.guestState
'notRunning'
>>> vm.runtime.powerState
'poweredOn'
>>>
```

**Resolution**

Using the power state and active tasks to identify the state of the vm. If the vm is not powered off after completion of all recent tasks then halting the vm before deletion.

**Unit-Testing**

Created 6 vms set them in different states such as :- poweredoff, suspended, poweredon, vm being cloned, deleting while taking the snapshot of the vm, running vm, vm that doesn't exist. The vms are deleted successfully. Logs are given below:

```
[root@my_machine test]# ./vsphereclient
1. CreateVMs           11. DeleteTemplate
2. DeleteVMs           12. GetDatacenterList
3. ShutDownVMs         13. GetDatastoreList
4. StartVMs            14. GetClusterList
5. StopVMs             15. GetHostList
6. ResetVMs            16. GetNetworkList
7. AddDisk             17. GetImageList
8. RemoveDisk          18. GetVmList
9. GetVMInfo           19. GetVisorList
10. ConvertToTemplate


        999. Default sequene "12 13 14 15 16 17 18 19 1 3 4 5 4 7 8 9 2"

Select one or sequence of method(s) to test:
Ex. 1 <Enter> for CreateVM or 1 2 3 <Enter> for CreateVM followed by Delete and ShutDown VM

Your option: 2
Testing DeleteVMs ...
power state :  poweredOff
Vm doesn't exist
power state :  poweredOff
power state :  poweredOff
power state :  poweredOff
power state :  poweredOff
power state :  poweredOff
DeleteVMs SUCCESSFUL
[{"vm_name":"new-tier-new_vm-6-20180323110119","ret":0,"ret_str":"VM{name: new-tier-new_vm-6-20180323110119}: DeleteVM action successful"},{"vm_name":"new-tier-new_vm-0-20180323110119","ret":0,"ret_str":"VM{name: new-tier-new_vm-0-20180323110119}: DeleteVM action successful"},{"vm_name":"new-tier-new_vm-3-20180323110119","ret":0,"ret_str":"VM{name: new-tier-new_vm-3-20180323110119}: DeleteVM action successful"},{"vm_name":"new-tier-new_vm-5-20180323110119","ret":0,"ret_str":"VM{name: new-tier-new_vm-5-20180323110119}: DeleteVM action successful"},{"vm_name":"new-tier-new_vm-1-20180323110119","ret":0,"ret_str":"VM{name: new-tier-new_vm-1-20180323110119}: DeleteVM action successful"},{"vm_name":"new-tier-new_vm-4-20180323110119","ret":0,"ret_str":"VM{name: new-tier-new_vm-4-20180323110119}: DeleteVM action successful"},{"vm_name":"new-tier-new_vm-2-20180323110119","ret":0,"ret_str":"VM{name: new-tier-new_vm-2-20180323110119}: DeleteVM action successful"}]

Sleeping for 5 seconds

[root@my_machine test]#
```