### PR TITLE
MRPHS-5435: distributed port-groups on vcenter 6.0 are not listed

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -2230,3 +2230,13 @@ func waitForTasksToFinish(vm *VM, tasks []types.ManagedObjectReference) {
 		tObj.Wait(vm.ctx)
 	}
 }
+
+// tagsHasKey: returns true if any of the tags has 'key'
+func tagsHasKey(tags []types.Tag, key string) bool {
+	for _, tag := range tags {
+		if tag.Key == key {
+			return true
+		}
+	}
+	return false
+}

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -42,6 +42,7 @@ const (
 	VISOR_FIELD = "template_type"
 	VISOR_VALUE = "visor"
 	MO_TYPE_VM  = "VirtualMachine"
+	UPLINK_TAG  = "SYSTEM/DVS.UPLINKPG"
 
 	// Constants for supproted values for Flavor:Name
 	FlavorSmall   = "small"
@@ -1305,12 +1306,11 @@ func getNetworks(vm *VM, networkMo []types.ManagedObjectReference) ([]map[string
 				"id": network.Self.Value}
 		case "DistributedVirtualPortgroup":
 			err := vm.collector.RetrieveOne(vm.ctx, networkMor,
-				[]string{"name", "config"}, &portGroup)
+				[]string{"name", "tag"}, &portGroup)
 			if err != nil {
 				return nil, err
 			}
-			if portGroup.Config.Uplink == nil ||
-				*portGroup.Config.Uplink {
+			if tagsHasKey(portGroup.Tag, UPLINK_TAG) {
 				continue
 			}
 			networkMap = map[string]string{"name": portGroup.Name,


### PR DESCRIPTION
**Jira-id**

MRPHS-5435

**Problem**

Distributed port-groups on vcenter 6.0 are not listed.  The uplink field used to check if the port group is an uplink or not was introduced in vcenter 6.5 and hence is nil in 6.0. Due to which the api skips network if the field is not available.

**Resolution**

The network uplinks are tagged with key '' in both 6.0 and 6.5 vcenter versions. Checking the key instead of uplink field to detect uplinks.

**Unit-testing**

Tried fetching network list in vcenter version 6.0 and 6.5. The networks are listed in both the vcenters.
Logs below:

```
star-vc

[root@my_machine test]# ./vsphereclient
1. CreateVMs           11. DeleteTemplate
2. DeleteVMs           12. GetDatacenterList
3. ShutDownVMs         13. GetDatastoreList
4. StartVMs            14. GetClusterList
5. StopVMs             15. GetHostList
6. ResetVMs            16. GetNetworkList
7. AddDisk             17. GetImageList
8. RemoveDisk          18. GetVmList
9. GetVMInfo           19. GetVisorList
10. ConvertToTemplate


        999. Default sequene "12 13 14 15 16 17 18 19 1 3 4 5 4 7 8 9 2"

Select one or sequence of method(s) to test:
Ex. 1 <Enter> for CreateVM or 1 2 3 <Enter> for CreateVM followed by Delete and ShutDown VM

Your option: 16
Testing GetNetworkList ...
GetNetworkList SUCCESSFUL:  [{"id":"network-1198","name":"DistributedPortGroup1"},{"id":"network-1533","name":"DummyPrivate-moved-to-distributed"},{"id":"network-15","name":"VM Network"},{"id":"network-16","name":"VM Private"},{"id":"network-16","name":"nativevmportgroup"},{"id":"network-16","name":"DistributedPrivateNetwork"}]

Sleeping for 5 seconds

[root@my_machine test]#


dev-vc


[root@my_machine test]# ./vsphereclient
1. CreateVMs           11. DeleteTemplate
2. DeleteVMs           12. GetDatacenterList
3. ShutDownVMs         13. GetDatastoreList
4. StartVMs            14. GetClusterList
5. StopVMs             15. GetHostList
6. ResetVMs            16. GetNetworkList
7. AddDisk             17. GetImageList
8. RemoveDisk          18. GetVmList
9. GetVMInfo           19. GetVisorList
10. ConvertToTemplate


        999. Default sequene "12 13 14 15 16 17 18 19 1 3 4 5 4 7 8 9 2"

Select one or sequence of method(s) to test:
Ex. 1 <Enter> for CreateVM or 1 2 3 <Enter> for CreateVM followed by Delete and ShutDown VM

Your option: 16
Testing GetNetworkList ...
GetNetworkList SUCCESSFUL:  [{"id":"network-8817","name":"DoNot Use this Private"},{"id":"network-1715","name":"Test Network"},{"id":"network-12","name":"VM Network"},{"id":"network-13","name":"VM Private"},{"id":"network-13","name":"Private Network"}]

Sleeping for 5 seconds

[root@my_machine test]#
```


<img width="727" alt="screen shot 2018-03-26 at 1 14 20 pm" src="https://user-images.githubusercontent.com/22026464/37893328-44d0eed4-30f8-11e8-85c8-d5c0670731e5.png">
<img width="705" alt="screen shot 2018-03-26 at 1 14 32 pm" src="https://user-images.githubusercontent.com/22026464/37893330-45800824-30f8-11e8-9805-29bb174b5258.png">
<img width="488" alt="screen shot 2018-03-26 at 1 18 37 pm" src="https://user-images.githubusercontent.com/22026464/37893332-46508508-30f8-11e8-939f-0f8fd6204bbf.png">
<img width="444" alt="screen shot 2018-03-26 at 1 18 50 pm" src="https://user-images.githubusercontent.com/22026464/37893333-46831e78-30f8-11e8-8fad-a93cbc9edc16.png">
